### PR TITLE
✨ feat: 주문 조회 관련 API 구현

### DIFF
--- a/src/main/java/com/jajaja/domain/order/controller/OrderController.java
+++ b/src/main/java/com/jajaja/domain/order/controller/OrderController.java
@@ -1,10 +1,13 @@
 package com.jajaja.domain.order.controller;
 
 import com.jajaja.domain.order.dto.response.OrderDetailResponseDto;
+import com.jajaja.domain.order.dto.response.PagingOrderListResponseDto;
 import com.jajaja.domain.order.service.OrderQueryService;
 import com.jajaja.global.apiPayload.ApiResponse;
+import com.jajaja.global.config.security.annotation.Auth;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -13,6 +16,16 @@ import org.springframework.web.bind.annotation.*;
 public class OrderController {
 
     private final OrderQueryService orderQueryService;
+
+    @Operation(
+            summary = "내 주문 목록 조회 API | by 지안/윤진수",
+            description = "사용자의 모든 주문 목록을 조회합니다."
+    )
+    @GetMapping("/me")
+    public ApiResponse<PagingOrderListResponseDto> getMyOrders(@Auth Long userId, Pageable pageable) {
+        PagingOrderListResponseDto pagingOrderListResponseDto = orderQueryService.getMyOrders(userId, pageable);
+        return ApiResponse.onSuccess(pagingOrderListResponseDto);
+    }
 
     @Operation(
             summary = "주문 상세 조회 API | by 지안/윤진수",

--- a/src/main/java/com/jajaja/domain/order/controller/OrderController.java
+++ b/src/main/java/com/jajaja/domain/order/controller/OrderController.java
@@ -1,0 +1,26 @@
+package com.jajaja.domain.order.controller;
+
+import com.jajaja.domain.order.dto.response.OrderDetailResponseDto;
+import com.jajaja.domain.order.service.OrderQueryService;
+import com.jajaja.global.apiPayload.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/orders")
+public class OrderController {
+
+    private final OrderQueryService orderQueryService;
+
+    @Operation(
+            summary = "주문 상세 조회 API | by 지안/윤진수",
+            description = "주문 상세 페이지를 조회합니다."
+    )
+    @GetMapping("/{orderId}")
+    public ApiResponse<OrderDetailResponseDto> getOrderById(@PathVariable Long orderId) {
+        OrderDetailResponseDto orderDetailResponseDto = orderQueryService.getOrderById(orderId);
+        return ApiResponse.onSuccess(orderDetailResponseDto);
+    }
+}

--- a/src/main/java/com/jajaja/domain/order/dto/response/OrderDeliveryDto.java
+++ b/src/main/java/com/jajaja/domain/order/dto/response/OrderDeliveryDto.java
@@ -1,0 +1,19 @@
+package com.jajaja.domain.order.dto.response;
+
+import com.jajaja.domain.delivery.entity.Delivery;
+import lombok.Builder;
+
+@Builder
+public record OrderDeliveryDto(
+        String name,
+        String phone,
+        String address
+) {
+    public static OrderDeliveryDto from(Delivery delivery) {
+        return OrderDeliveryDto.builder()
+                .name(delivery.getName())
+                .phone(delivery.getPhone())
+                .address(delivery.getAddress())
+                .build();
+    }
+}

--- a/src/main/java/com/jajaja/domain/order/dto/response/OrderDetailResponseDto.java
+++ b/src/main/java/com/jajaja/domain/order/dto/response/OrderDetailResponseDto.java
@@ -1,0 +1,26 @@
+package com.jajaja.domain.order.dto.response;
+
+import com.jajaja.domain.order.entity.Order;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Builder
+public record OrderDetailResponseDto(
+        LocalDateTime date,
+        String orderNumber,
+        List<OrderItemDto> items,
+        OrderDeliveryDto delivery,
+        OrderPaymentDto payment
+) {
+    public static OrderDetailResponseDto of(Order order, List<OrderItemDto> items) {
+        return OrderDetailResponseDto.builder()
+                .date(order.getCreatedAt())
+                .orderNumber(order.getOrderNumber())
+                .items(items)
+                .delivery(OrderDeliveryDto.from(order.getDelivery()))
+                .payment(OrderPaymentDto.from(order))
+                .build();
+    }
+}

--- a/src/main/java/com/jajaja/domain/order/dto/response/OrderItemDto.java
+++ b/src/main/java/com/jajaja/domain/order/dto/response/OrderItemDto.java
@@ -1,0 +1,23 @@
+package com.jajaja.domain.order.dto.response;
+
+import com.jajaja.domain.order.entity.OrderProduct;
+import com.jajaja.domain.order.entity.enums.OrderStatus;
+import com.jajaja.domain.team.entity.enums.TeamStatus;
+import lombok.Builder;
+
+@Builder
+public record OrderItemDto(
+        OrderStatus status,
+        TeamStatus teamStatus,
+        OrderItemProductDto product,
+        int price
+) {
+    public static OrderItemDto of(OrderProduct orderProduct, TeamStatus teamStatus) {
+        return OrderItemDto.builder()
+                .status(orderProduct.getStatus())
+                .teamStatus(teamStatus)
+                .product(OrderItemProductDto.from(orderProduct))
+                .price(orderProduct.getPrice())
+                .build();
+    }
+}

--- a/src/main/java/com/jajaja/domain/order/dto/response/OrderItemProductDto.java
+++ b/src/main/java/com/jajaja/domain/order/dto/response/OrderItemProductDto.java
@@ -1,0 +1,25 @@
+package com.jajaja.domain.order.dto.response;
+
+import com.jajaja.domain.order.entity.OrderProduct;
+import lombok.Builder;
+
+@Builder
+public record OrderItemProductDto(
+        long id,
+        String image,
+        String store,
+        String name,
+        String option,
+        int quantity
+) {
+    public static OrderItemProductDto from(OrderProduct orderProduct) {
+        return OrderItemProductDto.builder()
+                .id(orderProduct.getProduct().getId())
+                .image(orderProduct.getProduct().getImageUrl())
+                .store(orderProduct.getProduct().getStore())
+                .name(orderProduct.getProduct().getName())
+                .option(orderProduct.getProductOption().getName())
+                .quantity(orderProduct.getQuantity())
+                .build();
+    }
+}

--- a/src/main/java/com/jajaja/domain/order/dto/response/OrderListDto.java
+++ b/src/main/java/com/jajaja/domain/order/dto/response/OrderListDto.java
@@ -1,0 +1,22 @@
+package com.jajaja.domain.order.dto.response;
+
+import com.jajaja.domain.order.entity.Order;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Builder
+public record OrderListDto(
+        long id,
+        LocalDateTime date,
+        List<OrderItemDto> items
+) {
+    public static OrderListDto of(Order order, List<OrderItemDto> items) {
+        return OrderListDto.builder()
+                .id(order.getId())
+                .date(order.getCreatedAt())
+                .items(items)
+                .build();
+    }
+}

--- a/src/main/java/com/jajaja/domain/order/dto/response/OrderPaymentDto.java
+++ b/src/main/java/com/jajaja/domain/order/dto/response/OrderPaymentDto.java
@@ -1,0 +1,26 @@
+package com.jajaja.domain.order.dto.response;
+
+import com.jajaja.domain.order.entity.Order;
+import com.jajaja.domain.order.entity.enums.PaymentMethod;
+import lombok.Builder;
+
+@Builder
+public record OrderPaymentDto(
+        PaymentMethod method,
+        int amount,
+        int discount,
+        int pointUsed,
+        int shippingFee,
+        int finalAmount
+) {
+    public static OrderPaymentDto from(Order order) {
+        return OrderPaymentDto.builder()
+                .method(order.getPaymentMethod())
+                .amount(order.calculateAmount())
+                .discount(order.getDiscountAmount())
+                .pointUsed(order.getPointUsedAmount())
+                .shippingFee(order.getShippingFee())
+                .finalAmount(order.calculateFinalAmount())
+                .build();
+    }
+}

--- a/src/main/java/com/jajaja/domain/order/dto/response/PagingOrderListResponseDto.java
+++ b/src/main/java/com/jajaja/domain/order/dto/response/PagingOrderListResponseDto.java
@@ -1,0 +1,21 @@
+package com.jajaja.domain.order.dto.response;
+
+import com.jajaja.domain.order.entity.Order;
+import com.jajaja.global.apiPayload.PageResponse;
+import lombok.Builder;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+
+@Builder
+public record PagingOrderListResponseDto(
+        PageResponse page,
+        List<OrderListDto> orders
+) {
+    public static PagingOrderListResponseDto of(Page<Order> orderPage, List<OrderListDto> orderListDtos) {
+        return PagingOrderListResponseDto.builder()
+                .page(PageResponse.from(orderPage))
+                .orders(orderListDtos)
+                .build();
+    }
+}

--- a/src/main/java/com/jajaja/domain/order/entity/Order.java
+++ b/src/main/java/com/jajaja/domain/order/entity/Order.java
@@ -32,10 +32,6 @@ public class Order extends BaseEntity {
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
-    private OrderStatus status;
-
-    @Enumerated(EnumType.STRING)
-    @Column(nullable = false)
     private PaymentMethod paymentMethod;
 
     @Column(nullable = false)
@@ -46,6 +42,9 @@ public class Order extends BaseEntity {
 
     @Column(nullable = false)
     private Integer shippingFee;
+
+    @Column(length = 10, nullable = false)
+    private String orderNumber;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")

--- a/src/main/java/com/jajaja/domain/order/entity/Order.java
+++ b/src/main/java/com/jajaja/domain/order/entity/Order.java
@@ -2,7 +2,6 @@ package com.jajaja.domain.order.entity;
 
 import com.jajaja.domain.coupon.entity.Coupon;
 import com.jajaja.domain.delivery.entity.Delivery;
-import com.jajaja.domain.order.entity.enums.OrderStatus;
 import com.jajaja.domain.order.entity.enums.OrderType;
 import com.jajaja.domain.order.entity.enums.PaymentMethod;
 import com.jajaja.domain.team.entity.Team;
@@ -63,4 +62,14 @@ public class Order extends BaseEntity {
 
     @OneToMany(mappedBy = "order", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<OrderProduct> orderProducts = new ArrayList<>();
+
+    public int calculateAmount() {
+        return orderProducts.stream()
+                .mapToInt(product -> product.getPrice() * product.getQuantity())
+                .sum();
+    }
+
+    public int calculateFinalAmount() {
+        return calculateAmount() - discountAmount - pointUsedAmount + shippingFee;
+    }
 }

--- a/src/main/java/com/jajaja/domain/order/entity/Order.java
+++ b/src/main/java/com/jajaja/domain/order/entity/Order.java
@@ -5,6 +5,7 @@ import com.jajaja.domain.delivery.entity.Delivery;
 import com.jajaja.domain.order.entity.enums.OrderStatus;
 import com.jajaja.domain.order.entity.enums.OrderType;
 import com.jajaja.domain.order.entity.enums.PaymentMethod;
+import com.jajaja.domain.team.entity.Team;
 import com.jajaja.domain.user.entity.User;
 import com.jajaja.global.common.domain.BaseEntity;
 import jakarta.persistence.*;
@@ -57,6 +58,9 @@ public class Order extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "coupon_id")
     private Coupon coupon;
+
+    @OneToOne(mappedBy = "order", cascade = CascadeType.ALL)
+    private Team team;
 
     @OneToMany(mappedBy = "order", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<OrderProduct> orderProducts = new ArrayList<>();

--- a/src/main/java/com/jajaja/domain/order/entity/OrderProduct.java
+++ b/src/main/java/com/jajaja/domain/order/entity/OrderProduct.java
@@ -1,5 +1,6 @@
 package com.jajaja.domain.order.entity;
 
+import com.jajaja.domain.order.entity.enums.OrderStatus;
 import com.jajaja.domain.product.entity.Product;
 import com.jajaja.domain.product.entity.ProductOption;
 import com.jajaja.global.common.domain.BaseEntity;
@@ -23,6 +24,10 @@ public class OrderProduct extends BaseEntity {
 
     @Column(nullable = false)
     private Integer price;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private OrderStatus status;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "order_id")

--- a/src/main/java/com/jajaja/domain/order/repository/OrderRepository.java
+++ b/src/main/java/com/jajaja/domain/order/repository/OrderRepository.java
@@ -6,7 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
-public interface OrderRepository extends JpaRepository<Order, Long> {
+public interface OrderRepository extends JpaRepository<Order, Long>, OrderRepositoryCustom {
 
     @EntityGraph(attributePaths = {"orderProducts", "orderProducts.product", "orderProducts.productOption", "team", "delivery"})
     Optional<Order> findById(Long id);

--- a/src/main/java/com/jajaja/domain/order/repository/OrderRepository.java
+++ b/src/main/java/com/jajaja/domain/order/repository/OrderRepository.java
@@ -1,0 +1,13 @@
+package com.jajaja.domain.order.repository;
+
+import com.jajaja.domain.order.entity.Order;
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface OrderRepository extends JpaRepository<Order, Long> {
+
+    @EntityGraph(attributePaths = {"orderProducts", "orderProducts.product", "orderProducts.productOption", "team", "delivery"})
+    Optional<Order> findById(Long id);
+}

--- a/src/main/java/com/jajaja/domain/order/repository/OrderRepositoryCustom.java
+++ b/src/main/java/com/jajaja/domain/order/repository/OrderRepositoryCustom.java
@@ -1,0 +1,10 @@
+package com.jajaja.domain.order.repository;
+
+import com.jajaja.domain.order.entity.Order;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface OrderRepositoryCustom {
+
+    Page<Order> findByMemberId(Long memberId, Pageable pageable);
+}

--- a/src/main/java/com/jajaja/domain/order/repository/OrderRepositoryImpl.java
+++ b/src/main/java/com/jajaja/domain/order/repository/OrderRepositoryImpl.java
@@ -1,0 +1,63 @@
+package com.jajaja.domain.order.repository;
+
+import com.jajaja.domain.order.entity.Order;
+import com.jajaja.domain.order.entity.QOrder;
+import com.jajaja.domain.order.entity.QOrderProduct;
+import com.jajaja.domain.product.entity.QProduct;
+import com.jajaja.domain.product.entity.QProductOption;
+import com.jajaja.domain.team.entity.QTeam;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class OrderRepositoryImpl implements OrderRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Page<Order> findByMemberId(Long memberId, Pageable pageable) {
+        QOrder order = QOrder.order;
+        QOrderProduct orderProduct = QOrderProduct.orderProduct;
+        QProduct product = QProduct.product;
+        QProductOption productOption = QProductOption.productOption;
+        QTeam team = QTeam.team;
+
+        List<Long> orderIds = queryFactory
+                .select(order.id)
+                .from(order)
+                .where(order.member.id.eq(memberId))
+                .orderBy(order.createdAt.desc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        if (orderIds.isEmpty()) {
+            return Page.empty(pageable);
+        }
+
+        List<Order> orders = queryFactory
+                .selectFrom(order)
+                .distinct()
+                .leftJoin(order.orderProducts, orderProduct).fetchJoin()
+                .leftJoin(orderProduct.product, product).fetchJoin()
+                .leftJoin(orderProduct.productOption, productOption).fetchJoin()
+                .leftJoin(order.team, team).fetchJoin()
+                .where(order.id.in(orderIds))
+                .orderBy(order.createdAt.desc())
+                .fetch();
+
+        long count = Optional.ofNullable(
+                queryFactory.select(order.count()).from(order).where(order.member.id.eq(memberId)).fetchOne()
+        ).orElse(0L);
+
+        return new PageImpl<>(orders, pageable, count);
+    }
+}

--- a/src/main/java/com/jajaja/domain/order/service/OrderQueryService.java
+++ b/src/main/java/com/jajaja/domain/order/service/OrderQueryService.java
@@ -1,8 +1,12 @@
 package com.jajaja.domain.order.service;
 
 import com.jajaja.domain.order.dto.response.OrderDetailResponseDto;
+import com.jajaja.domain.order.dto.response.PagingOrderListResponseDto;
+import org.springframework.data.domain.Pageable;
 
 public interface OrderQueryService {
+
+    PagingOrderListResponseDto getMyOrders(Long userId, Pageable pageable);
 
     OrderDetailResponseDto getOrderById(Long orderId);
 }

--- a/src/main/java/com/jajaja/domain/order/service/OrderQueryService.java
+++ b/src/main/java/com/jajaja/domain/order/service/OrderQueryService.java
@@ -1,0 +1,8 @@
+package com.jajaja.domain.order.service;
+
+import com.jajaja.domain.order.dto.response.OrderDetailResponseDto;
+
+public interface OrderQueryService {
+
+    OrderDetailResponseDto getOrderById(Long orderId);
+}

--- a/src/main/java/com/jajaja/domain/order/service/OrderQueryServiceImpl.java
+++ b/src/main/java/com/jajaja/domain/order/service/OrderQueryServiceImpl.java
@@ -1,0 +1,37 @@
+package com.jajaja.domain.order.service;
+
+import com.jajaja.domain.order.dto.response.OrderDetailResponseDto;
+import com.jajaja.domain.order.dto.response.OrderItemDto;
+import com.jajaja.domain.order.entity.Order;
+import com.jajaja.domain.order.repository.OrderRepository;
+import com.jajaja.domain.team.entity.Team;
+import com.jajaja.domain.team.entity.enums.TeamStatus;
+import com.jajaja.global.apiPayload.code.status.ErrorStatus;
+import com.jajaja.global.apiPayload.exception.custom.BadRequestException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class OrderQueryServiceImpl implements OrderQueryService {
+
+    private final OrderRepository orderRepository;
+
+    public OrderDetailResponseDto getOrderById(Long orderId) {
+        Order order = orderRepository.findById(orderId)
+                .orElseThrow(() -> new BadRequestException(ErrorStatus.ORDER_NOT_FOUND));
+        TeamStatus teamStatus = Optional.ofNullable(order.getTeam())
+                .map(Team::getStatus)
+                .orElse(null);
+        List<OrderItemDto> items = order.getOrderProducts().stream()
+                .map(orderProduct -> OrderItemDto.of(orderProduct, teamStatus))
+                .collect(Collectors.toList());
+        return OrderDetailResponseDto.of(order, items);
+    }
+}

--- a/src/main/java/com/jajaja/domain/team/entity/Team.java
+++ b/src/main/java/com/jajaja/domain/team/entity/Team.java
@@ -1,5 +1,6 @@
 package com.jajaja.domain.team.entity;
 
+import com.jajaja.domain.order.entity.Order;
 import com.jajaja.domain.product.entity.Product;
 import com.jajaja.domain.team.entity.enums.TeamStatus;
 import com.jajaja.domain.user.entity.User;
@@ -37,5 +38,7 @@ public class Team extends BaseEntity {
     @JoinColumn(name = "product_id")
     private Product product;
 
-
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "order_id")
+    private Order order;
 }

--- a/src/main/java/com/jajaja/global/apiPayload/PageResponse.java
+++ b/src/main/java/com/jajaja/global/apiPayload/PageResponse.java
@@ -1,0 +1,29 @@
+package com.jajaja.global.apiPayload;
+
+import lombok.Builder;
+import org.springframework.data.domain.Page;
+
+@Builder
+public record PageResponse(
+        int size,
+        long totalElements,
+        int currentElements,
+        int totalPages,
+        int currentPage,
+        boolean hasNextPage,
+        boolean hasPreviousPage,
+        boolean isLast
+) {
+    public static PageResponse from(Page<?> page) {
+        return PageResponse.builder()
+                .size(page.getSize())
+                .totalElements(page.getTotalElements())
+                .currentElements(page.getNumberOfElements())
+                .totalPages(page.getTotalPages())
+                .currentPage(page.getNumber())
+                .hasNextPage(page.hasNext())
+                .hasPreviousPage(page.hasPrevious())
+                .isLast(page.isLast())
+                .build();
+    }
+}

--- a/src/main/java/com/jajaja/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/jajaja/global/apiPayload/code/status/ErrorStatus.java
@@ -33,7 +33,11 @@ public enum ErrorStatus implements BaseErrorCode {
     CART_NOT_FOUND(HttpStatus.BAD_REQUEST,  "CART4001", "장바구니기 없습니다."),
     
     // CART PRODUCT 관련 에러
-    CART_PRODUCT_NOT_FOUND(HttpStatus.BAD_REQUEST, "CARTPRODUCT4001", "장바구니에 해당 상품이 없습니다.");
+    CART_PRODUCT_NOT_FOUND(HttpStatus.BAD_REQUEST, "CARTPRODUCT4001", "장바구니에 해당 상품이 없습니다."),
+
+    // ORDER 관련 에러
+     ORDER_NOT_FOUND(HttpStatus.BAD_REQUEST, "ORDER4001", "주문이 없습니다."),
+    ;
 
     private final HttpStatus httpStatus;
     private final String code;


### PR DESCRIPTION
## 📋 작업 내용
- 주문 조회 관련 API 구현

## 🎯 관련 이슈
- closes #23 

## 📝 변경 사항
- [x] 주문 상세 조회 API 구현
- [x] 내 주문 목록 조회 API 구현
- [x] 페이징 응답 추가

## 📸 스크린샷 (선택사항)
- 필요한 경우 스크린샷 첨부

## ✅ 체크리스트
- [x] 코드 컨벤션 준수
- [x] 주석 작성
- [x] 문서 업데이트
- [x] 리뷰어 지정

## 💬 리뷰어에게 하고 싶은 말
### 설계 변경
- 주문 조회 시 팀 매칭 상태를 함께 조회해야 해서 주문-팀 연관관계를 설정했습니다.
- 상품별 배송 상태 조회를 위해 status 필드를 Order에서 OrderProduct로 옮겼습니다.
- 주문 테이블에 주문번호(order_number) 필드를 추가했습니다. (결제 시점에 무작위 자동 생성)
### 하고 싶은 말
- 주문의 결제 금액과 할인·포인트 차감 후 최종 결제 금액을 계산하는 코드를 Order 엔티티에 작성했습니다. 혹시 Util 클래스나 다른 곳으로 빼는게 좋을까요? 의견 부탁드리겠습니다!
- Controller에서 Pageable 객체를 받도록 설정했습니다. 스웨거에서 아래처럼 요청할 수 있는건 확인했는데, 이대로 둬도 될까요? 불필요한 'sort' query string이 스웨거에 나타나서 의견 여쭙니다.
```
http://localhost:8080/api/orders/me?page=0&size=1
```
- 페이지 메타데이터를 통일하면 좋을 것 같아서 PageResponse를 추가해봤습니다. 일단은 임의로 이렇게 사용한다고 가정하고 작성했습니다. PageResponse에 들어있는 메타데이터 포함해서 의견 많이 주시면 감사하겠습니다!!
```java
public ApiRespone<PagingOrderListResponseDto> getMyOrder();

public record PagingOrderListResponseDto(
        PageResponse page,
        List<OrderListDto> orders
) {}
```
- Collection fetchjoin과 paging을 같이 사용하면 전체를 불러온 후 메모리에서 페이징하는 이슈가 있어 QueryDSL 사용하여 id 값만 페이징하여 불러오고, 해당 id 값으로 fetchjoin 하여 조회하도록 구현했습니다.
```
WARN 93831 --- [nio-8080-exec-3] org.hibernate.orm.query : HHH90003004: firstResult/maxResults specified with collection fetch; applying in memory
```
- 사용자 엔티티는 User인데 다른 연관관계에는 전부 Member member, member_id로 되어있어 헷갈리는 것 같습니다. 하나로 통일해도 괜찮을까요? 제 생각에는 User를 Member로 바꾸는게 간단할 것 같습니다!