### PR TITLE
🐛 fix: SecurityConfig WHITELIST에 누락된 쉼표 추가

### DIFF
--- a/src/main/java/com/jajaja/global/config/security/SecurityConfig.java
+++ b/src/main/java/com/jajaja/global/config/security/SecurityConfig.java
@@ -28,7 +28,7 @@ public class SecurityConfig {
             "/v3/api-docs/**",
             "/api/auth/token",
             "/api/products/**",
-            "/api/search"
+            "/api/search/**",
             "/api/categories/**",
     };
 


### PR DESCRIPTION
## 📋 작업 내용
- SecurityConfig WHITELIST에 누락된 쉼표를 추가했습니다.
- /search 아래 두 endpoint 모두 비회원 접근이 가능하므로 /**를 추가했습니다.

## 🎯 관련 이슈
- closes #이슈번호

## 📝 변경 사항
- [x] 쉼표 추가
- [x] 해당 경로에 /** 추가

## 📸 스크린샷 (선택사항)
- 필요한 경우 스크린샷 첨부

## ✅ 체크리스트
- [x] 코드 컨벤션 준수
- [x] 주석 작성
- [x] 문서 업데이트
- [x] 리뷰어 지정

## 💬 리뷰어에게 하고 싶은 말
- 임의로 /** 추가해놨는데 원래 없는게 맞다면 수정하겠습니다!
