### PR TITLE
✨ feat: 리뷰 좋아요/취소 API 구현

### DIFF
--- a/src/main/java/com/jajaja/domain/member/service/MemberBusinessCategoryCommandServiceImpl.java
+++ b/src/main/java/com/jajaja/domain/member/service/MemberBusinessCategoryCommandServiceImpl.java
@@ -29,7 +29,7 @@ public class MemberBusinessCategoryCommandServiceImpl implements MemberBusinessC
     @Transactional
     public void registerUserBusinessCategory(Long userId, MemberBusinessCategoryRequestDto dto) {
         Member member = memberRepository.findById(userId)
-                .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
+                .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
 
         if (memberBusinessCategoryRepository.findByMember(member).isPresent()) {
             throw new GeneralException(ErrorStatus.BUSINESS_CATEGORY_ALREADY_REGISTERED);

--- a/src/main/java/com/jajaja/domain/product/controller/ProductController.java
+++ b/src/main/java/com/jajaja/domain/product/controller/ProductController.java
@@ -67,8 +67,8 @@ public class ProductController {
             description = "상품의 상세 페이지를 조회합니다."
     )
     @GetMapping("/{productId}")
-    public ApiResponse<ProductDetailResponseDto> getProductDetails(@Auth Long userId, @PathVariable Long productId) {
-        ProductDetailResponseDto responseDto = productQueryService.getProductDetail(userId, productId);
+    public ApiResponse<ProductDetailResponseDto> getProductDetails(@Auth Long memberId, @PathVariable Long productId) {
+        ProductDetailResponseDto responseDto = productQueryService.getProductDetail(memberId, productId);
         return ApiResponse.onSuccess(responseDto);
     }
 

--- a/src/main/java/com/jajaja/domain/product/service/ProductQueryService.java
+++ b/src/main/java/com/jajaja/domain/product/service/ProductQueryService.java
@@ -6,7 +6,7 @@ import com.jajaja.domain.product.dto.response.ProductDetailResponseDto;
 import org.springframework.data.domain.Pageable;
 
 public interface ProductQueryService {
-    ProductDetailResponseDto getProductDetail(Long userId, Long productId);
+    ProductDetailResponseDto getProductDetail(Long memberId, Long productId);
     HomeProductListResponseDto getProductList(Long userId, Long categoryId);
     CategoryProductListResponseDto getProductsBySubCategory(Long subcategoryId, String sort, Pageable pageable);
 }

--- a/src/main/java/com/jajaja/domain/product/service/ProductQueryServiceImpl.java
+++ b/src/main/java/com/jajaja/domain/product/service/ProductQueryServiceImpl.java
@@ -162,9 +162,9 @@ public class ProductQueryServiceImpl implements ProductQueryService {
     private Long resolveCategoryId(Long userId, Long categoryId) {
         if (userId != null) {
             Member member = memberRepository.findById(userId)
-                    .orElseThrow(() -> new BadRequestException(ErrorStatus.USER_NOT_FOUND));
+                    .orElseThrow(() -> new BadRequestException(ErrorStatus.MEMBER_NOT_FOUND));
             MemberBusinessCategory memberBusinessCategory = memberBusinessCategoryRepository.findByMember(member)
-                    .orElseThrow(() -> new BadRequestException(ErrorStatus.USER_BUSINESS_CATEGORY_NOT_FOUND));
+                    .orElseThrow(() -> new BadRequestException(ErrorStatus.MEMBER_BUSINESS_CATEGORY_NOT_FOUND));
             return memberBusinessCategory.getBusinessCategory().getId();
         }
         if (categoryId != null) {

--- a/src/main/java/com/jajaja/domain/product/service/ProductQueryServiceImpl.java
+++ b/src/main/java/com/jajaja/domain/product/service/ProductQueryServiceImpl.java
@@ -59,7 +59,7 @@ public class ProductQueryServiceImpl implements ProductQueryService {
     private final ProductConverter productConverter;
 
     @Override
-    public ProductDetailResponseDto getProductDetail(Long userId, Long productId) {
+    public ProductDetailResponseDto getProductDetail(Long memberId, Long productId) {
         Product product = productRepository.findById(productId)
                 .orElseThrow(() -> new BadRequestException(ErrorStatus.PRODUCT_NOT_FOUND));
 
@@ -82,8 +82,8 @@ public class ProductQueryServiceImpl implements ProductQueryService {
                 .findTop6ImageUrlsGroupedByReviewIds(reviewIds);
 
         // isLike 조회
-        Set<Integer> likedReviewIds = userId != null
-                ? reviewLikeRepository.findReviewIdsLikedByUser(userId, reviewIds)
+        Set<Integer> likedReviewIds = memberId != null
+                ? reviewLikeRepository.findReviewIdsLikedByUser(memberId, reviewIds)
                 : Set.of();
 
         // 병합

--- a/src/main/java/com/jajaja/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/jajaja/domain/review/controller/ReviewController.java
@@ -37,7 +37,7 @@ public class ReviewController {
     )
     @GetMapping("/{productId}")
     public ApiResponse<PagingReviewListResponseDto> getReviewList(
-            @Auth Long userId,
+            @Auth Long memberId,
             @PathVariable Long productId,
             @Parameter(description = "정렬 기준 (LATEST | RECOMMEND)", example = "LATEST")
             @RequestParam(required = false, defaultValue = "NEW") String sort,
@@ -48,7 +48,7 @@ public class ReviewController {
             @Parameter(description = "페이지 크기", example = "5")
             @RequestParam(defaultValue = "5") int size
             ) {
-        PagingReviewListResponseDto responseDto = reviewQueryService.getReviewList(userId, productId, sort, page, size);
+        PagingReviewListResponseDto responseDto = reviewQueryService.getReviewList(memberId, productId, sort, page, size);
         return ApiResponse.onSuccess(responseDto);
     }
 

--- a/src/main/java/com/jajaja/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/jajaja/domain/review/controller/ReviewController.java
@@ -2,13 +2,14 @@ package com.jajaja.domain.review.controller;
 
 import com.jajaja.domain.review.dto.response.PagingReviewListResponseDto;
 import com.jajaja.domain.review.dto.response.ReviewBriefResponseDto;
+import com.jajaja.domain.review.dto.response.ReviewLikeResponseDto;
+import com.jajaja.domain.review.service.ReviewLikeCommandService;
 import com.jajaja.domain.review.service.ReviewQueryService;
 import com.jajaja.global.apiPayload.ApiResponse;
 import com.jajaja.global.config.security.annotation.Auth;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Pageable;
 import org.springframework.web.bind.annotation.*;
 
 
@@ -18,6 +19,7 @@ import org.springframework.web.bind.annotation.*;
 public class ReviewController {
 
     private final ReviewQueryService reviewQueryService;
+    private final ReviewLikeCommandService reviewLikeCommandService;
 
     @Operation(
             summary = "리뷰 상세 조회 - 상단 API | by 지지/이지희",
@@ -49,4 +51,18 @@ public class ReviewController {
         PagingReviewListResponseDto responseDto = reviewQueryService.getReviewList(userId, productId, sort, page, size);
         return ApiResponse.onSuccess(responseDto);
     }
+
+    @Operation(
+            summary = "리뷰 좋아요/취소 API | by 지지/이지희",
+            description = "'하트' 버튼을 통해 해당 리뷰의 좋아요/취소를 수행하는 기능입니다."
+    )
+    @PatchMapping("/{reviewId}")
+    public ApiResponse<ReviewLikeResponseDto> patchReviewLike(
+            @Auth Long memberId,
+            @PathVariable Long reviewId
+    ) {
+        ReviewLikeResponseDto responseDto = reviewLikeCommandService.patchReviewLike(memberId, reviewId);
+        return ApiResponse.onSuccess(responseDto);
+    }
+
 }

--- a/src/main/java/com/jajaja/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/jajaja/domain/review/controller/ReviewController.java
@@ -38,7 +38,7 @@ public class ReviewController {
     )
     @GetMapping("/{productId}")
     public ApiResponse<PagingReviewListResponseDto> getReviewList(
-            @Auth Long userId,
+            @Auth Long memberId,
             @PathVariable Long productId,
             @Parameter(description = "정렬 기준 (LATEST | RECOMMEND)", example = "LATEST")
             @RequestParam(required = false, defaultValue = "NEW") String sort,

--- a/src/main/java/com/jajaja/domain/review/dto/response/ReviewLikeResponseDto.java
+++ b/src/main/java/com/jajaja/domain/review/dto/response/ReviewLikeResponseDto.java
@@ -1,0 +1,17 @@
+package com.jajaja.domain.review.dto.response;
+
+import com.jajaja.domain.review.entity.Review;
+import lombok.Builder;
+
+@Builder
+public record ReviewLikeResponseDto(
+        int reviewId,
+        Boolean isLike
+) {
+    public static ReviewLikeResponseDto of(Review review, boolean isLike) {
+        return ReviewLikeResponseDto.builder()
+                .reviewId(review.getId().intValue())
+                .isLike(isLike)
+                .build();
+    }
+}

--- a/src/main/java/com/jajaja/domain/review/repository/ReviewLikeRepository.java
+++ b/src/main/java/com/jajaja/domain/review/repository/ReviewLikeRepository.java
@@ -1,9 +1,14 @@
 package com.jajaja.domain.review.repository;
 
+import com.jajaja.domain.member.entity.Member;
+import com.jajaja.domain.review.entity.Review;
 import com.jajaja.domain.review.entity.ReviewLike;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface ReviewLikeRepository extends JpaRepository<ReviewLike, Long>, ReviewLikeRepositoryCustom {
+    Optional<ReviewLike> findByReviewAndMember(Review review, Member member);
 }

--- a/src/main/java/com/jajaja/domain/review/repository/ReviewLikeRepositoryCustom.java
+++ b/src/main/java/com/jajaja/domain/review/repository/ReviewLikeRepositoryCustom.java
@@ -4,5 +4,5 @@ import java.util.List;
 import java.util.Set;
 
 public interface ReviewLikeRepositoryCustom {
-    Set<Integer> findReviewIdsLikedByUser(Long userId, List<Integer> reviewIds);
+    Set<Integer> findReviewIdsLikedByUser(Long memberId, List<Integer> reviewIds);
 }

--- a/src/main/java/com/jajaja/domain/review/repository/ReviewLikeRepositoryImpl.java
+++ b/src/main/java/com/jajaja/domain/review/repository/ReviewLikeRepositoryImpl.java
@@ -16,7 +16,7 @@ public class ReviewLikeRepositoryImpl implements ReviewLikeRepositoryCustom {
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public Set<Integer> findReviewIdsLikedByUser(Long userId, List<Integer> reviewIds) {
+    public Set<Integer> findReviewIdsLikedByUser(Long memberId, List<Integer> reviewIds) {
         QReviewLike rl = QReviewLike.reviewLike;
 
         return new HashSet<>(
@@ -24,7 +24,7 @@ public class ReviewLikeRepositoryImpl implements ReviewLikeRepositoryCustom {
                         .select(rl.review.id.intValue())
                         .from(rl)
                         .where(
-                                rl.member.id.eq(userId),
+                                rl.member.id.eq(memberId),
                                 rl.review.id.intValue().in(reviewIds)
                         )
                         .fetch()

--- a/src/main/java/com/jajaja/domain/review/service/ReviewLikeCommandService.java
+++ b/src/main/java/com/jajaja/domain/review/service/ReviewLikeCommandService.java
@@ -1,0 +1,7 @@
+package com.jajaja.domain.review.service;
+
+import com.jajaja.domain.review.dto.response.ReviewLikeResponseDto;
+
+public interface ReviewLikeCommandService {
+    ReviewLikeResponseDto patchReviewLike(Long memberId, Long reviewId);
+}

--- a/src/main/java/com/jajaja/domain/review/service/ReviewLikeCommandServiceImpl.java
+++ b/src/main/java/com/jajaja/domain/review/service/ReviewLikeCommandServiceImpl.java
@@ -1,0 +1,55 @@
+package com.jajaja.domain.review.service;
+
+import com.jajaja.domain.member.entity.Member;
+import com.jajaja.domain.member.repository.MemberRepository;
+import com.jajaja.domain.review.dto.response.ReviewLikeResponseDto;
+import com.jajaja.domain.review.entity.Review;
+import com.jajaja.domain.review.entity.ReviewLike;
+import com.jajaja.domain.review.repository.ReviewLikeRepository;
+import com.jajaja.domain.review.repository.ReviewRepository;
+import com.jajaja.global.apiPayload.code.status.ErrorStatus;
+import com.jajaja.global.apiPayload.exception.custom.BadRequestException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class ReviewLikeCommandServiceImpl implements ReviewLikeCommandService {
+
+    private final MemberRepository memberRepository;
+    private final ReviewRepository reviewRepository;
+    private final ReviewLikeRepository reviewLikeRepository;
+
+    @Override
+    public ReviewLikeResponseDto patchReviewLike(Long memberId, Long reviewId) {
+        if (memberId == null) {
+            throw new BadRequestException(ErrorStatus.MEMBER_REQUIRED);
+        }
+
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new BadRequestException(ErrorStatus.MEMBER_NOT_FOUND));
+
+        Review review = reviewRepository.findById(reviewId)
+                .orElseThrow(() -> new BadRequestException(ErrorStatus.REVIEW_NOT_FOUND));
+
+        Optional<ReviewLike> existing = reviewLikeRepository.findByReviewAndMember(review, member);
+
+        if (existing.isPresent()) {
+            reviewLikeRepository.delete(existing.get());
+            return ReviewLikeResponseDto.of(review, false);
+        } else {
+            ReviewLike like = ReviewLike.builder()
+                    .review(review)
+                    .member(member)
+                    .build();
+            reviewLikeRepository.save(like);
+            return ReviewLikeResponseDto.of(review, true);
+        }
+    }
+
+
+}

--- a/src/main/java/com/jajaja/domain/review/service/ReviewLikeCommandServiceImpl.java
+++ b/src/main/java/com/jajaja/domain/review/service/ReviewLikeCommandServiceImpl.java
@@ -26,10 +26,6 @@ public class ReviewLikeCommandServiceImpl implements ReviewLikeCommandService {
 
     @Override
     public ReviewLikeResponseDto patchReviewLike(Long memberId, Long reviewId) {
-        if (memberId == null) {
-            throw new BadRequestException(ErrorStatus.MEMBER_REQUIRED);
-        }
-
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new BadRequestException(ErrorStatus.MEMBER_NOT_FOUND));
 

--- a/src/main/java/com/jajaja/domain/review/service/ReviewQueryService.java
+++ b/src/main/java/com/jajaja/domain/review/service/ReviewQueryService.java
@@ -2,7 +2,6 @@ package com.jajaja.domain.review.service;
 
 import com.jajaja.domain.review.dto.response.PagingReviewListResponseDto;
 import com.jajaja.domain.review.dto.response.ReviewBriefResponseDto;
-import org.springframework.data.domain.Pageable;
 
 
 public interface ReviewQueryService {

--- a/src/main/java/com/jajaja/domain/review/service/ReviewQueryService.java
+++ b/src/main/java/com/jajaja/domain/review/service/ReviewQueryService.java
@@ -6,5 +6,5 @@ import com.jajaja.domain.review.dto.response.ReviewBriefResponseDto;
 
 public interface ReviewQueryService {
     ReviewBriefResponseDto getReviewBriefInfo(Long productId);
-    PagingReviewListResponseDto getReviewList(Long userId, Long productId, String sort, int page, int size);
+    PagingReviewListResponseDto getReviewList(Long memberId, Long productId, String sort, int page, int size);
 }

--- a/src/main/java/com/jajaja/domain/review/service/ReviewQueryServiceImpl.java
+++ b/src/main/java/com/jajaja/domain/review/service/ReviewQueryServiceImpl.java
@@ -45,7 +45,7 @@ public class ReviewQueryServiceImpl implements ReviewQueryService {
     }
 
     @Override
-    public PagingReviewListResponseDto getReviewList(Long userId, Long productId, String sort, int page, int size) {
+    public PagingReviewListResponseDto getReviewList(Long memberId, Long productId, String sort, int page, int size) {
         productRepository.findById(productId)
                 .orElseThrow(() -> new BadRequestException(ErrorStatus.PRODUCT_NOT_FOUND));
 
@@ -70,8 +70,8 @@ public class ReviewQueryServiceImpl implements ReviewQueryService {
                 .findTop6ImageUrlsGroupedByReviewIds(reviewIds);
 
         // isLike 조회
-        Set<Integer> likedReviewIds = userId != null
-                ? reviewLikeRepository.findReviewIdsLikedByUser(userId, reviewIds)
+        Set<Integer> likedReviewIds = memberId != null
+                ? reviewLikeRepository.findReviewIdsLikedByUser(memberId, reviewIds)
                 : Set.of();
 
         // ReviewListDto로 병합

--- a/src/main/java/com/jajaja/domain/team/controller/TeamController.java
+++ b/src/main/java/com/jajaja/domain/team/controller/TeamController.java
@@ -20,8 +20,8 @@ public class TeamController {
             description = "‘팀 생성하기 버튼’을 통해 해당 상품의 팀을 생성합니다. 해당 유저는 만들어진 팀의 리더가 됩니다."
     )
     @PostMapping("/{productId}")
-    public ApiResponse<TeamCreateResponseDto> createTeam(@Auth Long userId, @PathVariable Long productId) {
-        TeamCreateResponseDto responseDto = teamCommandService.createTeam(userId, productId);
+    public ApiResponse<TeamCreateResponseDto> createTeam(@Auth Long memberId, @PathVariable Long productId) {
+        TeamCreateResponseDto responseDto = teamCommandService.createTeam(memberId, productId);
         return ApiResponse.onSuccess(responseDto);
     }
 
@@ -30,8 +30,8 @@ public class TeamController {
             description = "‘참여 버튼’을 통해 해당 팀에 참여하는 기능입니다."
     )
     @PostMapping("/join/{teamId}")
-    public ApiResponse<String> joinTeam(@Auth Long userId, @PathVariable Long teamId) {
-        teamCommandService.joinTeam(userId, teamId);
+    public ApiResponse<String> joinTeam(@Auth Long memberId, @PathVariable Long teamId) {
+        teamCommandService.joinTeam(memberId, teamId);
         return ApiResponse.onSuccess("팀 참여가 완료되었습니다.");
     }
 
@@ -39,8 +39,8 @@ public class TeamController {
             summary = "장바구니 상품 팀 참여 API | by 지지/이지희",
             description = "장바구니 상품의 '팀 참여하기' 버튼을 누를 시, 팀 참여가 진행됩니다.")
     @PostMapping("/carts/join/{productId}")
-    public ApiResponse<String> joinTeamInCarts(@Auth Long userId, @PathVariable Long productId) {
-        teamCommandService.joinTeamInCarts(userId, productId);
+    public ApiResponse<String> joinTeamInCarts(@Auth Long memberId, @PathVariable Long productId) {
+        teamCommandService.joinTeamInCarts(memberId, productId);
         return ApiResponse.onSuccess("장바구니 내 상품의 팀 참여가 완료되었습니다.");
     }
 }

--- a/src/main/java/com/jajaja/domain/team/service/TeamCommandService.java
+++ b/src/main/java/com/jajaja/domain/team/service/TeamCommandService.java
@@ -3,7 +3,7 @@ package com.jajaja.domain.team.service;
 import com.jajaja.domain.team.dto.response.TeamCreateResponseDto;
 
 public interface TeamCommandService {
-    TeamCreateResponseDto createTeam(Long userId, Long productId);
-    void joinTeam(Long userId, Long teamId);
-    void joinTeamInCarts(Long userId, Long productId);
+    TeamCreateResponseDto createTeam(Long memberId, Long productId);
+    void joinTeam(Long memberId, Long teamId);
+    void joinTeamInCarts(Long memberId, Long productId);
 }

--- a/src/main/java/com/jajaja/domain/team/service/TeamCommandServiceImpl.java
+++ b/src/main/java/com/jajaja/domain/team/service/TeamCommandServiceImpl.java
@@ -1,7 +1,6 @@
 package com.jajaja.domain.team.service;
 
 import com.jajaja.domain.cart.entity.Cart;
-import com.jajaja.domain.cart.repository.CartRepository;
 import com.jajaja.domain.product.entity.Product;
 import com.jajaja.domain.product.repository.ProductRepository;
 import com.jajaja.domain.team.dto.response.TeamCreateResponseDto;
@@ -27,12 +26,11 @@ public class TeamCommandServiceImpl implements TeamCommandService {
     private final MemberRepository memberRepository;
     private final ProductRepository productRepository;
     private final TeamRepository teamRepository;
-    private final CartRepository cartRepository;
     private final TeamCommonService teamCommonService;
 
     @Override
-    public TeamCreateResponseDto createTeam(Long userId, Long productId) {
-        Member member = memberRepository.findById(userId).orElseThrow(() -> new BadRequestException(ErrorStatus.MEMBER_NOT_FOUND));
+    public TeamCreateResponseDto createTeam(Long memberId, Long productId) {
+        Member member = memberRepository.findById(memberId).orElseThrow(() -> new BadRequestException(ErrorStatus.MEMBER_NOT_FOUND));
 
         Product product = productRepository.findById(productId).orElseThrow(() -> new BadRequestException(ErrorStatus.PRODUCT_NOT_FOUND));
 
@@ -49,8 +47,8 @@ public class TeamCommandServiceImpl implements TeamCommandService {
     }
 
     @Override
-    public void joinTeam(Long userId, Long teamId) {
-        Member member = memberRepository.findById(userId)
+    public void joinTeam(Long memberId, Long teamId) {
+        Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new BadRequestException(ErrorStatus.MEMBER_NOT_FOUND));
 
         Team team = teamRepository.findById(teamId)
@@ -60,8 +58,8 @@ public class TeamCommandServiceImpl implements TeamCommandService {
     }
 
     @Override
-    public void joinTeamInCarts(Long userId, Long productId) {
-        Member member = memberRepository.findById(userId).orElseThrow(() -> new BadRequestException(ErrorStatus.MEMBER_NOT_FOUND));
+    public void joinTeamInCarts(Long memberId, Long productId) {
+        Member member = memberRepository.findById(memberId).orElseThrow(() -> new BadRequestException(ErrorStatus.MEMBER_NOT_FOUND));
 
         List<Team> matchingTeams = teamRepository.findMatchingTeamsByProductId(productId);
 

--- a/src/main/java/com/jajaja/domain/team/service/TeamCommandServiceImpl.java
+++ b/src/main/java/com/jajaja/domain/team/service/TeamCommandServiceImpl.java
@@ -32,7 +32,7 @@ public class TeamCommandServiceImpl implements TeamCommandService {
 
     @Override
     public TeamCreateResponseDto createTeam(Long userId, Long productId) {
-        Member member = memberRepository.findById(userId).orElseThrow(() -> new BadRequestException(ErrorStatus.USER_NOT_FOUND));
+        Member member = memberRepository.findById(userId).orElseThrow(() -> new BadRequestException(ErrorStatus.MEMBER_NOT_FOUND));
 
         Product product = productRepository.findById(productId).orElseThrow(() -> new BadRequestException(ErrorStatus.PRODUCT_NOT_FOUND));
 
@@ -51,7 +51,7 @@ public class TeamCommandServiceImpl implements TeamCommandService {
     @Override
     public void joinTeam(Long userId, Long teamId) {
         Member member = memberRepository.findById(userId)
-                .orElseThrow(() -> new BadRequestException(ErrorStatus.USER_NOT_FOUND));
+                .orElseThrow(() -> new BadRequestException(ErrorStatus.MEMBER_NOT_FOUND));
 
         Team team = teamRepository.findById(teamId)
                 .orElseThrow(() -> new BadRequestException(ErrorStatus.TEAM_NOT_FOUND));
@@ -61,7 +61,7 @@ public class TeamCommandServiceImpl implements TeamCommandService {
 
     @Override
     public void joinTeamInCarts(Long userId, Long productId) {
-        Member member = memberRepository.findById(userId).orElseThrow(() -> new BadRequestException(ErrorStatus.USER_NOT_FOUND));
+        Member member = memberRepository.findById(userId).orElseThrow(() -> new BadRequestException(ErrorStatus.MEMBER_NOT_FOUND));
 
         List<Team> matchingTeams = teamRepository.findMatchingTeamsByProductId(productId);
 

--- a/src/main/java/com/jajaja/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/jajaja/global/apiPayload/code/status/ErrorStatus.java
@@ -16,10 +16,11 @@ public enum ErrorStatus implements BaseErrorCode {
     _UNAUTHORIZED(HttpStatus.UNAUTHORIZED,"COMMON401","인증이 필요합니다."),
     _FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON403", "금지된 요청입니다."),
 
-    // USER 관련 에러
-    USER_NOT_FOUND(HttpStatus.BAD_REQUEST, "USER4001", "사용자가 없습니다."),
-    USER_BUSINESS_CATEGORY_NOT_FOUND(HttpStatus.BAD_REQUEST, "USERBUSINESS4002", "사용자의 업종 정보가 없습니다."),
-    
+    // MEMBER 관련 에러
+    MEMBER_NOT_FOUND(HttpStatus.BAD_REQUEST, "MEMBER4001", "사용자가 없습니다."),
+    MEMBER_BUSINESS_CATEGORY_NOT_FOUND(HttpStatus.BAD_REQUEST, "MEMBERBUSINESS4002", "사용자의 업종 정보가 없습니다."),
+    MEMBER_REQUIRED(HttpStatus.BAD_REQUEST, "MEMBER4003", "회원만 사용할 수 있는 기능입니다."),
+
     // BUSINESS CATEGORY 관련 에러
     BUSINESS_CATEGORY_NOT_FOUND(HttpStatus.BAD_REQUEST, "CATEGORY4001", "업종이 존재하지 않습니다."),
     BUSINESS_CATEGORY_ALREADY_REGISTERED(HttpStatus.BAD_REQUEST, "CATEGORY4002", "이미 업종이 등록된 사용자입니다."),
@@ -53,6 +54,9 @@ public enum ErrorStatus implements BaseErrorCode {
   
     // ORDER 관련 에러
      ORDER_NOT_FOUND(HttpStatus.BAD_REQUEST, "ORDER4001", "주문이 없습니다."),
+
+    // REVIEW 관련 에러
+    REVIEW_NOT_FOUND(HttpStatus.BAD_REQUEST, "REVIEW4001", "리뷰가 없습니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/jajaja/global/config/security/SecurityConfig.java
+++ b/src/main/java/com/jajaja/global/config/security/SecurityConfig.java
@@ -28,14 +28,19 @@ public class SecurityConfig {
     private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
 
     private static final String[] WHITELIST = {
-            "/",
-            "/swagger/**",
-            "/swagger-ui/**",
-            "/v3/api-docs/**",
-            "/api/auth/**",
-            "/api/products/**",
-            "/api/search/**",
-            "/api/categories/**",
+            "/", "/swagger/**", "/swagger-ui/**", "/v3/api-docs/**", "/api/auth/**"
+    };
+
+    private static final String[] GET_WHITELIST = {
+            "/api/products/**", "/api/search/**", "/api/categories/**", "/api/reviews/**"
+    };
+
+    private static final String[] POST_WHITELIST = {
+            // 인증 필요 없이 허용할 POST 요청 URI가 있다면 여기에 추가
+    };
+
+    private static final String[] PATCH_WHITELIST = {
+            // 인증 필요 없이 허용할 PATCH 요청 URI가 있다면 여기에 추가
     };
 
     @Bean
@@ -55,9 +60,9 @@ public class SecurityConfig {
                 .authorizeHttpRequests(authorizationManagerRequestMatcherRegistry ->
                         authorizationManagerRequestMatcherRegistry
                                 .requestMatchers(WHITELIST).permitAll()
-                                .requestMatchers(HttpMethod.GET, "/api/reviews/**").permitAll()
-                                .requestMatchers(HttpMethod.POST, "/api/reviews/**").authenticated()
-                                .requestMatchers(HttpMethod.PATCH, "/api/reviews/**").authenticated()
+                                .requestMatchers(HttpMethod.GET, GET_WHITELIST).permitAll()
+                                .requestMatchers(HttpMethod.POST, POST_WHITELIST).permitAll()
+                                .requestMatchers(HttpMethod.PATCH, PATCH_WHITELIST).permitAll()
                                 .anyRequest().authenticated()
                 )
                 .addFilterBefore(new JwtAuthenticationFilter(jwtProvider), UsernamePasswordAuthenticationFilter.class)

--- a/src/main/java/com/jajaja/global/config/security/SecurityConfig.java
+++ b/src/main/java/com/jajaja/global/config/security/SecurityConfig.java
@@ -5,6 +5,7 @@ import com.jajaja.global.config.security.oauth.CustomOAuth2SuccessHandler;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -28,7 +29,6 @@ public class SecurityConfig {
             "/v3/api-docs/**",
             "/api/auth/token",
             "/api/products/**",
-            "/api/reviews/**",
             "/api/search/**",
             "/api/categories/**",
     };
@@ -48,6 +48,9 @@ public class SecurityConfig {
                 .authorizeHttpRequests(authorizationManagerRequestMatcherRegistry ->
                         authorizationManagerRequestMatcherRegistry
                                 .requestMatchers(WHITELIST).permitAll()
+                                .requestMatchers(HttpMethod.GET, "/api/reviews/**").permitAll()
+                                .requestMatchers(HttpMethod.POST, "/api/reviews/**").authenticated()
+                                .requestMatchers(HttpMethod.PATCH, "/api/reviews/**").authenticated()
                                 .anyRequest().authenticated()
                 )
                 .addFilterBefore(new JwtAuthenticationFilter(jwtProvider), UsernamePasswordAuthenticationFilter.class)


### PR DESCRIPTION
## 📋 작업 내용
- 리뷰 좋아요/취소 API 구현했습니다.

## 🎯 관련 이슈
- closes #40 

## 📝 변경 사항
- [x] 리뷰 좋아요/취소 API 
- [x] Member 관련 status 수정
- [x] userId -> memberId로 수정 (본인 분량만!)

## 📸 스크린샷 (선택사항)
- 필요한 경우 스크린샷 첨부

## ✅ 체크리스트
- [x] 코드 컨벤션 준수
- [x] 주석 작성
- [x] 문서 업데이트
- [x] 리뷰어 지정

## 💬 리뷰어에게 하고 싶은 말
WHITELIST에 리뷰 관련 기능을 추가하면서 멤버가 아닌 사람도 좋아요 기능을 접근할 수 있도록 되어있습니다.
따라서 patchReviewLike에서 member 조회할 때 아래와 같은 예외 처리를 해두었는데, 이 방법이 괜찮은지 혹은 그냥 WHITELIST를 세분화 하는 게 좋을지 의견 부탁드립니다!
```
if (memberId == null) {
            throw new BadRequestException(ErrorStatus.MEMBER_REQUIRED);
        }
```