### PR TITLE
✨ Feat: 알림 관련 API 구현

### DIFF
--- a/src/main/java/com/jajaja/domain/notification/controller/NotificationController.java
+++ b/src/main/java/com/jajaja/domain/notification/controller/NotificationController.java
@@ -1,0 +1,62 @@
+package com.jajaja.domain.notification.controller;
+
+import java.util.List;
+
+import com.jajaja.domain.notification.repository.NotificationSseEmitterRepository;
+import com.jajaja.global.config.security.annotation.Auth;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+import com.jajaja.global.apiPayload.ApiResponse;
+import com.jajaja.domain.notification.dto.NotificationResponseDto;
+import com.jajaja.domain.notification.service.NotificationService;
+
+@RestController
+@RequestMapping("/api/notifications")
+@RequiredArgsConstructor
+public class NotificationController {
+
+    private final NotificationService notificationService;
+    private final NotificationSseEmitterRepository emitterRepository;
+
+    @Operation(
+            summary = "알림 실시간 구독 API | by 구름/윤윤지",
+            description = "사용자가 실시간으로 알림을 받기 위해 SSE 연결을 맺는 API입니다."
+    )
+    @GetMapping(value = "/subscribe", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+    public SseEmitter subscribe(@Auth Long memberId) {
+        return emitterRepository.add(memberId);
+    }
+
+    @Operation(
+            summary = "알림 목록 조회 API | by 구름/윤윤지",
+            description = "사용자의 알림 목록을 조회합니다."
+    )
+    @GetMapping
+    public ApiResponse<List<NotificationResponseDto>> getNotifications(@Auth Long memberId) {
+        List<NotificationResponseDto> notifications = notificationService.getNotifications(memberId);
+        return ApiResponse.onSuccess(notificationService.getNotifications(memberId));
+    }
+
+    @Operation(
+            summary = "알림 단건 읽음 API | by 구름/윤윤지",
+            description = "사용자의 특정 알림을 읽음 상태로 변경합니다."
+    )
+    @PatchMapping("/{notificationId}/read")
+    public ApiResponse<Void> markAsRead(@PathVariable("notificationId") Long notificationId, @Auth Long memberId) {
+        notificationService.markAsRead(notificationId, memberId);
+        return ApiResponse.onSuccess(null);
+    }
+
+    @Operation(
+            summary = "알림 전체 읽음 API | by 구름/윤윤지",
+            description = "사용자의 모든 알림을 읽음 상태로 변경합니다."
+    )
+    @PatchMapping("/read-all")
+    public ApiResponse<Void> markAllAsRead(@Auth Long memberId) {
+        notificationService.markAllAsRead(memberId);
+        return ApiResponse.onSuccess(null);
+    }
+}

--- a/src/main/java/com/jajaja/domain/notification/converter/NotificationConverter.java
+++ b/src/main/java/com/jajaja/domain/notification/converter/NotificationConverter.java
@@ -1,0 +1,19 @@
+package com.jajaja.domain.notification.converter;
+
+import org.springframework.stereotype.Component;
+import com.jajaja.domain.notification.dto.NotificationResponseDto;
+import com.jajaja.domain.notification.entity.Notification;
+
+@Component
+public class NotificationConverter {
+
+    public NotificationResponseDto toResponseDto(Notification notification) {
+        return new NotificationResponseDto(
+                notification.getId(),
+                notification.getType(),
+                notification.getBody(),
+                notification.getIsRead(),
+                notification.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/com/jajaja/domain/notification/dto/NotificationCreateRequestDto.java
+++ b/src/main/java/com/jajaja/domain/notification/dto/NotificationCreateRequestDto.java
@@ -1,0 +1,10 @@
+package com.jajaja.domain.notification.dto;
+
+import com.jajaja.domain.notification.entity.enums.NotificationType;
+
+public record NotificationCreateRequestDto(
+        Long memberId,
+        NotificationType type,
+        String body
+) {
+}

--- a/src/main/java/com/jajaja/domain/notification/dto/NotificationResponseDto.java
+++ b/src/main/java/com/jajaja/domain/notification/dto/NotificationResponseDto.java
@@ -1,0 +1,14 @@
+package com.jajaja.domain.notification.dto;
+
+import com.jajaja.domain.notification.entity.enums.NotificationType;
+
+import java.time.LocalDateTime;
+
+public record NotificationResponseDto(
+        Long id,
+        NotificationType type,
+        String body,
+        boolean isRead,
+        LocalDateTime createdAt
+) {
+}

--- a/src/main/java/com/jajaja/domain/notification/entity/Notification.java
+++ b/src/main/java/com/jajaja/domain/notification/entity/Notification.java
@@ -1,6 +1,7 @@
 package com.jajaja.domain.notification.entity;
 
 import com.jajaja.domain.member.entity.Member;
+import com.jajaja.domain.notification.entity.enums.NotificationType;
 import com.jajaja.global.common.domain.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
@@ -16,16 +17,22 @@ public class Notification extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Enumerated(EnumType.STRING)
     @Column(nullable = false, length = 100)
-    private String type;
+    private NotificationType type;
 
     @Column(nullable = false, length = 512)
     private String body;
 
     @Column(nullable = false)
-    private Boolean isRead;
+    @Builder.Default
+    private Boolean isRead = false;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
+
+    public void markAsRead() {
+        this.isRead = true;
+    }
 }

--- a/src/main/java/com/jajaja/domain/notification/entity/enums/NotificationType.java
+++ b/src/main/java/com/jajaja/domain/notification/entity/enums/NotificationType.java
@@ -1,0 +1,7 @@
+package com.jajaja.domain.notification.entity.enums;
+
+public enum NotificationType {
+    MATCHING,     // 팀 매칭 관련
+    DELIVERY,     // 배송 관련
+    COUPON_AD     // 쿠폰/광고 관련
+}

--- a/src/main/java/com/jajaja/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/jajaja/domain/notification/repository/NotificationRepository.java
@@ -1,0 +1,7 @@
+package com.jajaja.domain.notification.repository;
+
+import com.jajaja.domain.notification.entity.Notification;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface NotificationRepository extends JpaRepository<Notification, Long>, NotificationRepositoryCustom {
+}

--- a/src/main/java/com/jajaja/domain/notification/repository/NotificationRepositoryCustom.java
+++ b/src/main/java/com/jajaja/domain/notification/repository/NotificationRepositoryCustom.java
@@ -1,0 +1,9 @@
+package com.jajaja.domain.notification.repository;
+
+import com.jajaja.domain.notification.entity.Notification;
+import java.util.List;
+
+public interface NotificationRepositoryCustom {
+    List<Notification> findNotificationsByMemberId(Long memberId);
+    int markAllAsReadByMemberId(Long memberId);
+}

--- a/src/main/java/com/jajaja/domain/notification/repository/NotificationRepositoryImpl.java
+++ b/src/main/java/com/jajaja/domain/notification/repository/NotificationRepositoryImpl.java
@@ -1,0 +1,33 @@
+package com.jajaja.domain.notification.repository;
+
+import com.jajaja.domain.notification.entity.Notification;
+import com.jajaja.domain.notification.entity.QNotification;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class NotificationRepositoryImpl implements NotificationRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<Notification> findNotificationsByMemberId(Long memberId) {
+        QNotification n = QNotification.notification;
+        return queryFactory.selectFrom(n)
+                .where(n.member.id.eq(memberId))
+                .orderBy(n.id.desc())
+                .fetch();
+    }
+
+    @Override
+    public int markAllAsReadByMemberId(Long memberId) {
+        QNotification n = QNotification.notification;
+        return (int) queryFactory.update(n)
+                .set(n.isRead, true)
+                .where(n.member.id.eq(memberId).and(n.isRead.isFalse()))
+                .execute();
+    }
+}

--- a/src/main/java/com/jajaja/domain/notification/repository/NotificationSseEmitterRepository.java
+++ b/src/main/java/com/jajaja/domain/notification/repository/NotificationSseEmitterRepository.java
@@ -1,0 +1,58 @@
+package com.jajaja.domain.notification.repository;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@Component
+public class NotificationSseEmitterRepository {
+
+    private static final Long DEFAULT_TIMEOUT = 60L * 1000 * 10;
+    private final Map<Long, List<SseEmitter>> emitters = new ConcurrentHashMap<>();
+
+    public SseEmitter add(Long memberId) {
+        SseEmitter emitter = new SseEmitter(DEFAULT_TIMEOUT);
+        emitter.onCompletion(() -> remove(memberId, emitter));
+        emitter.onTimeout(() -> remove(memberId, emitter));
+        emitter.onError((ex) -> remove(memberId, emitter));
+
+        emitters.computeIfAbsent(memberId, k -> new ArrayList<>()).add(emitter);
+
+        return emitter;
+    }
+
+    public void send(Long memberId, Object data) {
+        List<SseEmitter> memberEmitters = emitters.get(memberId);
+        if (memberEmitters == null || memberEmitters.isEmpty()) {
+            return;
+        }
+
+        List<SseEmitter> dead = new ArrayList<>();
+        for (SseEmitter emitter : memberEmitters) {
+            try {
+                emitter.send(SseEmitter.event().name("alarm").data(data));
+            } catch (IOException e) {
+                dead.add(emitter);
+            }
+        }
+
+        if (!dead.isEmpty()) {
+            memberEmitters.removeAll(dead);
+        }
+    }
+
+    private void remove(Long memberId, SseEmitter emitter) {
+        List<SseEmitter> memberEmitters = emitters.get(memberId);
+        if (memberEmitters == null) {
+            return;
+        }
+        memberEmitters.remove(emitter);
+        if (memberEmitters.isEmpty()) {
+            emitters.remove(memberId);
+        }
+    }
+}

--- a/src/main/java/com/jajaja/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/jajaja/domain/notification/service/NotificationService.java
@@ -1,0 +1,12 @@
+package com.jajaja.domain.notification.service;
+
+import java.util.List;
+import com.jajaja.domain.notification.dto.NotificationCreateRequestDto;
+import com.jajaja.domain.notification.dto.NotificationResponseDto;
+
+public interface NotificationService {
+    Long createNotification(NotificationCreateRequestDto requestDto);
+    List<NotificationResponseDto> getNotifications(Long memberId);
+    void markAsRead(Long notificationId, Long memberId);
+    int markAllAsRead(Long memberId);
+}

--- a/src/main/java/com/jajaja/domain/notification/service/NotificationServiceImpl.java
+++ b/src/main/java/com/jajaja/domain/notification/service/NotificationServiceImpl.java
@@ -1,0 +1,78 @@
+package com.jajaja.domain.notification.service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import com.jajaja.domain.notification.converter.NotificationConverter;
+import com.jajaja.domain.notification.repository.NotificationSseEmitterRepository;
+import com.jajaja.global.apiPayload.code.status.ErrorStatus;
+import com.jajaja.global.apiPayload.exception.custom.BadRequestException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import com.jajaja.domain.member.entity.Member;
+import com.jajaja.domain.member.repository.MemberRepository;
+import com.jajaja.domain.notification.dto.NotificationCreateRequestDto;
+import com.jajaja.domain.notification.dto.NotificationResponseDto;
+import com.jajaja.domain.notification.entity.Notification;
+import com.jajaja.domain.notification.repository.NotificationRepository;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class NotificationServiceImpl implements NotificationService {
+
+    private final NotificationRepository notificationRepository;
+    private final MemberRepository memberRepository;
+    private final NotificationSseEmitterRepository emitterRepository;
+    private final NotificationConverter converter;
+
+    @Override
+    @Transactional
+    public Long createNotification(NotificationCreateRequestDto requestDto) {
+        Member member = memberRepository.findById(requestDto.memberId())
+                .orElseThrow(() -> new BadRequestException(ErrorStatus.MEMBER_NOT_FOUND));
+
+        Notification notification = Notification.builder()
+                .member(member)
+                .type(requestDto.type())
+                .body(requestDto.body())
+                .isRead(false)
+                .build();
+
+        Notification saved = notificationRepository.save(notification);
+
+        emitterRepository.send(member.getId(), converter.toResponseDto(saved));
+
+        return saved.getId();
+    }
+
+    @Override
+    public List<NotificationResponseDto> getNotifications(Long memberId) {
+        return notificationRepository.findNotificationsByMemberId(memberId).stream()
+                .map(converter::toResponseDto)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    @Transactional
+    public int markAllAsRead(Long memberId) {
+        return notificationRepository.markAllAsReadByMemberId(memberId);
+    }
+
+    @Override
+    @Transactional
+    public void markAsRead(Long notificationId, Long memberId) {
+        Notification notification = notificationRepository.findById(notificationId)
+                .orElseThrow(() -> new BadRequestException(ErrorStatus.NOTIFICATION_NOT_FOUND));
+        validateOwnership(notification, memberId);
+        notification.markAsRead();
+    }
+
+    private void validateOwnership(Notification notification, Long memberId) {
+        if (!notification.getMember().getId().equals(memberId)) {
+            throw new AccessDeniedException(ErrorStatus.NOTIFICATION_ACCESS_DENIED.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/jajaja/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/jajaja/global/apiPayload/code/status/ErrorStatus.java
@@ -69,6 +69,10 @@ public enum ErrorStatus implements BaseErrorCode {
 
     // REVIEW 관련 에러
     REVIEW_NOT_FOUND(HttpStatus.BAD_REQUEST, "REVIEW4001", "리뷰가 없습니다."),
+
+    // NOTIFICATION 관련 에러
+    NOTIFICATION_NOT_FOUND(HttpStatus.BAD_REQUEST, "NOTIFICATION4001", "알림이 없습니다."),
+    NOTIFICATION_ACCESS_DENIED(HttpStatus.FORBIDDEN, "NOTIFICATION4031", "해당 알림에 대한 접근 권한이 없습니다."),
     ;
 
     private final HttpStatus httpStatus;


### PR DESCRIPTION
## 📋 작업 내용
- 알림 관련 API를 구현했습니다.

## 🎯 관련 이슈
- closes #34 

## 📝 변경 사항
- [ ] 알림 생성 메서드 구현
- [ ] 알림 실시간 구독 API 구현
- [ ] 알림 목록 조회 API 구현
- [ ] 알림 단 건 읽음 API 구현
- [ ] 알림 전체 읽음 API 구현

## 📸 스크린샷 (선택사항)
<img width="1238" height="281" alt="image" src="https://github.com/user-attachments/assets/9b782792-ce68-4ae7-91c8-b655a5282950" />

## ✅ 체크리스트
- [ ] 코드 컨벤션 준수
- [ ] 주석 작성
- [ ] 문서 업데이트
- [ ] 리뷰어 지정

## 💬 리뷰어에게 하고 싶은 말
-  SSE 알림 구현은 처음 해봐서 부족한 점이 많습니다! 잘못된 부분이 있다면 바로 알려주세요 🐱 
- 알림을 생성하실 때는 `notificationService.createNotification(new NotificationCreateRequestDto(memberId, NotificationType.MATCHING, "팀 매칭이 완료되었습니다."));` 이런 식으로 이용하시면 됩니다!
- NotificationType은 Enum 타입이며, `MATCHING, DELIVERY, COUPON_AD`가 있습니다.
