### PR TITLE
✨ feat: 배송지 관련 API 구현

### DIFF
--- a/src/main/java/com/jajaja/domain/delivery/controller/DeliveryController.java
+++ b/src/main/java/com/jajaja/domain/delivery/controller/DeliveryController.java
@@ -1,0 +1,29 @@
+package com.jajaja.domain.delivery.controller;
+
+import com.jajaja.domain.delivery.dto.DeliveryResponseDto;
+import com.jajaja.domain.delivery.service.DeliveryQueryService;
+import com.jajaja.global.apiPayload.ApiResponse;
+import com.jajaja.global.config.security.annotation.Auth;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/delivery")
+public class DeliveryController {
+	
+	private final DeliveryQueryService deliveryQueryService;
+	
+	@Operation(
+			summary = "배송지 목록 조회 API | by 엠마/신윤지",
+			description = "배송지 목록을 조회합니다.")
+	@GetMapping("/")
+	public ApiResponse<List<DeliveryResponseDto>> getDeliveriesByMemberId(@Auth Long memberId) {
+		return ApiResponse.onSuccess(deliveryQueryService.getDeliveriesByMemberId(memberId));
+	}
+}

--- a/src/main/java/com/jajaja/domain/delivery/controller/DeliveryController.java
+++ b/src/main/java/com/jajaja/domain/delivery/controller/DeliveryController.java
@@ -24,7 +24,7 @@ public class DeliveryController {
 	@Operation(
 			summary = "배송지 목록 조회 API | by 엠마/신윤지",
 			description = "배송지 목록을 조회합니다.")
-	@GetMapping("/")
+	@GetMapping
 	public ApiResponse<List<DeliveryResponseDto>> getDeliveriesByMemberId(@Auth Long memberId) {
 		return ApiResponse.onSuccess(deliveryQueryService.getDeliveriesByMemberId(memberId));
 	}
@@ -33,7 +33,7 @@ public class DeliveryController {
 			summary = "배송지 추가 API | by 엠마/신윤지",
 			description = "배송지를 새로 추가합니다."
 	)
-	@PostMapping("/")
+	@PostMapping
 	public ApiResponse<String> addDeliveryAddress(@Auth Long memberId, @Valid DeliveryRequestDto request) {
 		deliveryCommandService.addDeliveryAddress(memberId, request);
 		return ApiResponse.onSuccess("성공적으로 배송지를 추가하였습니다.");

--- a/src/main/java/com/jajaja/domain/delivery/controller/DeliveryController.java
+++ b/src/main/java/com/jajaja/domain/delivery/controller/DeliveryController.java
@@ -43,7 +43,7 @@ public class DeliveryController {
 			summary = "배송지 수정 API | by 엠마/신윤지",
 			description = "기존에 저장되어 있던 배송지를 수정합니다."
 	)
-	@PostMapping("/{deliveryId}")
+	@PatchMapping("/{deliveryId}")
 	public ApiResponse<String> updateDeliveryAddress(@Auth Long memberId, @RequestParam Long deliveryId, @Valid DeliveryRequestDto request) {
 		deliveryCommandService.updateDeliveryAddress(memberId, deliveryId, request);
 		return ApiResponse.onSuccess("성공적으로 배송지를 수정하였습니다.");

--- a/src/main/java/com/jajaja/domain/delivery/controller/DeliveryController.java
+++ b/src/main/java/com/jajaja/domain/delivery/controller/DeliveryController.java
@@ -40,10 +40,20 @@ public class DeliveryController {
 	}
 	
 	@Operation(
+			summary = "배송지 수정 API | by 엠마/신윤지",
+			description = "기존에 저장되어 있던 배송지를 수정합니다."
+	)
+	@PostMapping("/{deliveryId}")
+	public ApiResponse<String> updateDeliveryAddress(@Auth Long memberId, @RequestParam Long deliveryId, @Valid DeliveryRequestDto request) {
+		deliveryCommandService.updateDeliveryAddress(memberId, deliveryId, request);
+		return ApiResponse.onSuccess("성공적으로 배송지를 수정하였습니다.");
+	}
+	
+	@Operation(
 			summary = "배송지 삭제 API | by 엠마/신윤지",
 			description = "기존에 저장되어 있던 배송지를 삭제합니다."
 	)
-	@DeleteMapping("/")
+	@DeleteMapping("/{deliveryId}")
 	public ApiResponse<String> deleteDeliveryAddress(@Auth Long memberId, @RequestParam Long deliveryId) {
 		deliveryCommandService.deleteDeliveryAddress(memberId, deliveryId);
 		return ApiResponse.onSuccess("성공적으로 배송지를 삭제하였습니다.");

--- a/src/main/java/com/jajaja/domain/delivery/controller/DeliveryController.java
+++ b/src/main/java/com/jajaja/domain/delivery/controller/DeliveryController.java
@@ -9,10 +9,7 @@ import com.jajaja.global.config.security.annotation.Auth;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -40,5 +37,15 @@ public class DeliveryController {
 	public ApiResponse<String> addDeliveryAddress(@Auth Long memberId, @Valid DeliveryAddRequestDto request) {
 		deliveryCommandService.addDeliveryAddress(memberId, request);
 		return ApiResponse.onSuccess("성공적으로 배송지를 추가하였습니다.");
+	}
+	
+	@Operation(
+			summary = "배송지 삭제 API | by 엠마/신윤지",
+			description = "기존에 저장되어 있던 배송지를 삭제합니다."
+	)
+	@DeleteMapping("/")
+	public ApiResponse<String> deleteDeliveryAddress(@Auth Long memberId, @RequestParam Long deliveryId) {
+		deliveryCommandService.deleteDeliveryAddress(memberId, deliveryId);
+		return ApiResponse.onSuccess("성공적으로 배송지를 삭제하였습니다.");
 	}
 }

--- a/src/main/java/com/jajaja/domain/delivery/controller/DeliveryController.java
+++ b/src/main/java/com/jajaja/domain/delivery/controller/DeliveryController.java
@@ -1,6 +1,6 @@
 package com.jajaja.domain.delivery.controller;
 
-import com.jajaja.domain.delivery.dto.DeliveryAddRequestDto;
+import com.jajaja.domain.delivery.dto.DeliveryRequestDto;
 import com.jajaja.domain.delivery.dto.DeliveryResponseDto;
 import com.jajaja.domain.delivery.service.DeliveryCommandService;
 import com.jajaja.domain.delivery.service.DeliveryQueryService;
@@ -34,7 +34,7 @@ public class DeliveryController {
 			description = "배송지를 새로 추가합니다."
 	)
 	@PostMapping("/")
-	public ApiResponse<String> addDeliveryAddress(@Auth Long memberId, @Valid DeliveryAddRequestDto request) {
+	public ApiResponse<String> addDeliveryAddress(@Auth Long memberId, @Valid DeliveryRequestDto request) {
 		deliveryCommandService.addDeliveryAddress(memberId, request);
 		return ApiResponse.onSuccess("성공적으로 배송지를 추가하였습니다.");
 	}

--- a/src/main/java/com/jajaja/domain/delivery/controller/DeliveryController.java
+++ b/src/main/java/com/jajaja/domain/delivery/controller/DeliveryController.java
@@ -1,12 +1,16 @@
 package com.jajaja.domain.delivery.controller;
 
+import com.jajaja.domain.delivery.dto.DeliveryAddRequestDto;
 import com.jajaja.domain.delivery.dto.DeliveryResponseDto;
+import com.jajaja.domain.delivery.service.DeliveryCommandService;
 import com.jajaja.domain.delivery.service.DeliveryQueryService;
 import com.jajaja.global.apiPayload.ApiResponse;
 import com.jajaja.global.config.security.annotation.Auth;
 import io.swagger.v3.oas.annotations.Operation;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -14,10 +18,11 @@ import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/delivery")
+@RequestMapping("/api/addresses")
 public class DeliveryController {
 	
 	private final DeliveryQueryService deliveryQueryService;
+	private final DeliveryCommandService deliveryCommandService;
 	
 	@Operation(
 			summary = "배송지 목록 조회 API | by 엠마/신윤지",
@@ -25,5 +30,15 @@ public class DeliveryController {
 	@GetMapping("/")
 	public ApiResponse<List<DeliveryResponseDto>> getDeliveriesByMemberId(@Auth Long memberId) {
 		return ApiResponse.onSuccess(deliveryQueryService.getDeliveriesByMemberId(memberId));
+	}
+	
+	@Operation(
+			summary = "배송지 추가 API | by 엠마/신윤지",
+			description = "배송지를 새로 추가합니다."
+	)
+	@PostMapping("/")
+	public ApiResponse<String> addDeliveryAddress(@Auth Long memberId, @Valid DeliveryAddRequestDto request) {
+		deliveryCommandService.addDeliveryAddress(memberId, request);
+		return ApiResponse.onSuccess("성공적으로 배송지를 추가하였습니다.");
 	}
 }

--- a/src/main/java/com/jajaja/domain/delivery/dto/DeliveryAddRequestDto.java
+++ b/src/main/java/com/jajaja/domain/delivery/dto/DeliveryAddRequestDto.java
@@ -1,0 +1,30 @@
+package com.jajaja.domain.delivery.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public record DeliveryAddRequestDto(
+		@NotBlank(message = "이름은 필수입니다.")
+		@Size(max = 10)
+		String name,
+		
+		@NotBlank(message = "전화번호는 필수입니다.")
+		@Size(min = 13, max = 13)
+		String phone,
+		
+		@NotBlank(message = "주소는 필수입니다.")
+		String address,
+		
+		String addressDetail,
+		
+		@NotBlank(message = "우편번호는 필수입니다.")
+		@Size(min = 5, max = 5)
+		String zipcode,
+		
+		String buildingPassword,
+		
+		@NotNull(message = "기본 배송지 여부는 필수입니다.")
+		Boolean isDefault
+) {
+}

--- a/src/main/java/com/jajaja/domain/delivery/dto/DeliveryRequestDto.java
+++ b/src/main/java/com/jajaja/domain/delivery/dto/DeliveryRequestDto.java
@@ -4,7 +4,7 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
-public record DeliveryAddRequestDto(
+public record DeliveryRequestDto(
 		@NotBlank(message = "이름은 필수입니다.")
 		@Size(max = 10)
 		String name,

--- a/src/main/java/com/jajaja/domain/delivery/dto/DeliveryResponseDto.java
+++ b/src/main/java/com/jajaja/domain/delivery/dto/DeliveryResponseDto.java
@@ -1,0 +1,29 @@
+package com.jajaja.domain.delivery.dto;
+
+import com.jajaja.domain.delivery.entity.Delivery;
+import lombok.Builder;
+
+@Builder
+public record DeliveryResponseDto(
+		Long id,
+		String name,
+		String phone,
+		String address,
+		String addressDetail,
+		String zipcode,
+		String doorPassword,
+		Boolean isDefault
+) {
+	public static DeliveryResponseDto of(Delivery delivery) {
+		return DeliveryResponseDto.builder()
+				.id(delivery.getId())
+				.name(delivery.getName())
+				.phone(delivery.getPhone())
+				.address(delivery.getAddress())
+				.addressDetail(delivery.getAddressDetail())
+				.zipcode(delivery.getZipcode())
+				.doorPassword(delivery.getDoorPassword())
+				.isDefault(delivery.getIsDefault())
+				.build();
+	}
+}

--- a/src/main/java/com/jajaja/domain/delivery/dto/DeliveryResponseDto.java
+++ b/src/main/java/com/jajaja/domain/delivery/dto/DeliveryResponseDto.java
@@ -11,7 +11,7 @@ public record DeliveryResponseDto(
 		String address,
 		String addressDetail,
 		String zipcode,
-		String doorPassword,
+		String buildingPassword,
 		Boolean isDefault
 ) {
 	public static DeliveryResponseDto of(Delivery delivery) {
@@ -22,7 +22,7 @@ public record DeliveryResponseDto(
 				.address(delivery.getAddress())
 				.addressDetail(delivery.getAddressDetail())
 				.zipcode(delivery.getZipcode())
-				.doorPassword(delivery.getDoorPassword())
+				.buildingPassword(delivery.getBuildingPassword())
 				.isDefault(delivery.getIsDefault())
 				.build();
 	}

--- a/src/main/java/com/jajaja/domain/delivery/entity/Delivery.java
+++ b/src/main/java/com/jajaja/domain/delivery/entity/Delivery.java
@@ -47,4 +47,21 @@ public class Delivery extends BaseEntity {
 
     @OneToMany(mappedBy = "delivery")
     private List<Order> orders = new ArrayList<>();
+    
+    public static Delivery create(String name, String phone, String address, String addressDetail, String zipcode, String buildingPassword, Boolean isDefault, Member member) {
+        return Delivery.builder()
+                .name(name)
+                .phone(phone)
+                .address(address)
+                .addressDetail(addressDetail)
+                .zipcode(zipcode)
+                .buildingPassword(buildingPassword)
+                .isDefault(isDefault)
+                .member(member)
+                .build();
+    }
+    
+    public void removeDefault() {
+        this.isDefault = false;
+    }
 }

--- a/src/main/java/com/jajaja/domain/delivery/entity/Delivery.java
+++ b/src/main/java/com/jajaja/domain/delivery/entity/Delivery.java
@@ -36,7 +36,7 @@ public class Delivery extends BaseEntity {
     private String zipcode;
 
     @Column(length = 255)
-    private String doorPassword;
+    private String buildingPassword;
 
     @Column(nullable = false)
     private Boolean isDefault;

--- a/src/main/java/com/jajaja/domain/delivery/entity/Delivery.java
+++ b/src/main/java/com/jajaja/domain/delivery/entity/Delivery.java
@@ -61,6 +61,16 @@ public class Delivery extends BaseEntity {
                 .build();
     }
     
+    public void update(String name, String phone, String address, String addressDetail, String zipcode, String buildingPassword, Boolean isDefault) {
+        this.name = name;
+        this.phone = phone;
+        this.address = address;
+        this.addressDetail = addressDetail;
+        this.zipcode = zipcode;
+        this.buildingPassword = buildingPassword;
+        this.isDefault = isDefault;
+    }
+    
     public void removeDefault() {
         this.isDefault = false;
     }

--- a/src/main/java/com/jajaja/domain/delivery/repository/DeliveryRepository.java
+++ b/src/main/java/com/jajaja/domain/delivery/repository/DeliveryRepository.java
@@ -1,0 +1,13 @@
+package com.jajaja.domain.delivery.repository;
+
+import com.jajaja.domain.delivery.entity.Delivery;
+import com.jajaja.domain.member.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface DeliveryRepository extends JpaRepository<Delivery, Long> {
+	List<Delivery> findAllByMember(Member member);
+}

--- a/src/main/java/com/jajaja/domain/delivery/repository/DeliveryRepository.java
+++ b/src/main/java/com/jajaja/domain/delivery/repository/DeliveryRepository.java
@@ -6,8 +6,10 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface DeliveryRepository extends JpaRepository<Delivery, Long> {
 	List<Delivery> findAllByMember(Member member);
+	Optional<Delivery> findByMemberAndIsDefaultIsTrue(Member member);
 }

--- a/src/main/java/com/jajaja/domain/delivery/service/DeliveryCommandService.java
+++ b/src/main/java/com/jajaja/domain/delivery/service/DeliveryCommandService.java
@@ -4,4 +4,5 @@ import com.jajaja.domain.delivery.dto.DeliveryAddRequestDto;
 
 public interface DeliveryCommandService {
 	void addDeliveryAddress(Long memberId, DeliveryAddRequestDto request);
+	void deleteDeliveryAddress(Long memberId,  Long deliveryId);
 }

--- a/src/main/java/com/jajaja/domain/delivery/service/DeliveryCommandService.java
+++ b/src/main/java/com/jajaja/domain/delivery/service/DeliveryCommandService.java
@@ -1,0 +1,7 @@
+package com.jajaja.domain.delivery.service;
+
+import com.jajaja.domain.delivery.dto.DeliveryAddRequestDto;
+
+public interface DeliveryCommandService {
+	void addDeliveryAddress(Long memberId, DeliveryAddRequestDto request);
+}

--- a/src/main/java/com/jajaja/domain/delivery/service/DeliveryCommandService.java
+++ b/src/main/java/com/jajaja/domain/delivery/service/DeliveryCommandService.java
@@ -5,4 +5,5 @@ import com.jajaja.domain.delivery.dto.DeliveryRequestDto;
 public interface DeliveryCommandService {
 	void addDeliveryAddress(Long memberId, DeliveryRequestDto request);
 	void deleteDeliveryAddress(Long memberId,  Long deliveryId);
+	void updateDeliveryAddress(Long memberId, Long deliveryId, DeliveryRequestDto request);
 }

--- a/src/main/java/com/jajaja/domain/delivery/service/DeliveryCommandService.java
+++ b/src/main/java/com/jajaja/domain/delivery/service/DeliveryCommandService.java
@@ -1,8 +1,8 @@
 package com.jajaja.domain.delivery.service;
 
-import com.jajaja.domain.delivery.dto.DeliveryAddRequestDto;
+import com.jajaja.domain.delivery.dto.DeliveryRequestDto;
 
 public interface DeliveryCommandService {
-	void addDeliveryAddress(Long memberId, DeliveryAddRequestDto request);
+	void addDeliveryAddress(Long memberId, DeliveryRequestDto request);
 	void deleteDeliveryAddress(Long memberId,  Long deliveryId);
 }

--- a/src/main/java/com/jajaja/domain/delivery/service/DeliveryCommandServiceImpl.java
+++ b/src/main/java/com/jajaja/domain/delivery/service/DeliveryCommandServiceImpl.java
@@ -1,0 +1,45 @@
+package com.jajaja.domain.delivery.service;
+
+import com.jajaja.domain.delivery.dto.DeliveryAddRequestDto;
+import com.jajaja.domain.delivery.entity.Delivery;
+import com.jajaja.domain.delivery.repository.DeliveryRepository;
+import com.jajaja.domain.member.entity.Member;
+import com.jajaja.domain.member.repository.MemberRepository;
+import com.jajaja.global.apiPayload.code.status.ErrorStatus;
+import com.jajaja.global.apiPayload.exception.handler.DeliveryHandler;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class DeliveryCommandServiceImpl implements DeliveryCommandService{
+	
+	private final DeliveryRepository deliveryRepository;
+	private final MemberRepository memberRepository;
+	
+	@Override
+	public void addDeliveryAddress(Long memberId, DeliveryAddRequestDto request) {
+		Member member = memberRepository.findById(memberId).orElseThrow(
+				() -> new DeliveryHandler(ErrorStatus.MEMBER_NOT_FOUND)
+		);
+		
+		if(request.isDefault()) {
+			if(deliveryRepository.findByMemberAndIsDefaultIsTrue(member).isPresent()) {
+				throw new DeliveryHandler(ErrorStatus.DELIVERY_ALREADY_DEFAULT);
+			}
+		}
+		
+		deliveryRepository.save(Delivery.builder()
+				.name(request.name())
+				.phone(request.phone())
+				.address(request.address())
+				.addressDetail(request.addressDetail())
+				.zipcode(request.zipcode())
+				.buildingPassword(request.buildingPassword())
+				.isDefault(request.isDefault())
+				.member(member)
+				.build());
+	}
+}

--- a/src/main/java/com/jajaja/domain/delivery/service/DeliveryCommandServiceImpl.java
+++ b/src/main/java/com/jajaja/domain/delivery/service/DeliveryCommandServiceImpl.java
@@ -6,6 +6,7 @@ import com.jajaja.domain.delivery.repository.DeliveryRepository;
 import com.jajaja.domain.member.entity.Member;
 import com.jajaja.domain.member.repository.MemberRepository;
 import com.jajaja.global.apiPayload.code.status.ErrorStatus;
+import com.jajaja.global.apiPayload.exception.handler.CartHandler;
 import com.jajaja.global.apiPayload.exception.handler.DeliveryHandler;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -41,5 +42,19 @@ public class DeliveryCommandServiceImpl implements DeliveryCommandService{
 				.isDefault(request.isDefault())
 				.member(member)
 				.build());
+	}
+	
+	@Override
+	public void deleteDeliveryAddress(Long memberId, Long deliveryId) {
+		Delivery delivery = deliveryRepository.findById(deliveryId).orElseThrow(
+				() -> new DeliveryHandler(ErrorStatus.DELIVERY_NOT_FOUND)
+		);
+		
+		Member member = memberRepository.findById(memberId).orElseThrow( () -> new CartHandler(ErrorStatus.MEMBER_NOT_FOUND));
+		//  배송지 데이터베이스에 저장된 멤버와 현재 로그인 된 멤버가 다를 경우
+		if(delivery.getMember() != member) {
+			throw new DeliveryHandler(ErrorStatus.DELIVERY_MEMBER_NOT_MATCH);
+		}
+		deliveryRepository.delete(delivery);
 	}
 }

--- a/src/main/java/com/jajaja/domain/delivery/service/DeliveryCommandServiceImpl.java
+++ b/src/main/java/com/jajaja/domain/delivery/service/DeliveryCommandServiceImpl.java
@@ -47,6 +47,25 @@ public class DeliveryCommandServiceImpl implements DeliveryCommandService{
 		deliveryRepository.delete(getOwnDelivery(member, deliveryId));
 	}
 	
+	@Override
+	public void updateDeliveryAddress(Long memberId, Long deliveryId, DeliveryRequestDto request) {
+		Member member = memberRepository.findById(memberId).orElseThrow( () -> new DeliveryHandler(ErrorStatus.MEMBER_NOT_FOUND));
+		Delivery delivery = getOwnDelivery(member, deliveryId);
+		
+		if(request.isDefault()) {
+			updateDefaultAddress(member);
+		}
+		delivery.update(
+				request.name(),
+				request.phone(),
+				request.address(),
+				request.addressDetail(),
+				request.zipcode(),
+				request.buildingPassword(),
+				request.isDefault()
+		);
+	}
+	
 	private void updateDefaultAddress(Member  member) {
 		deliveryRepository.findByMemberAndIsDefaultIsTrue(member)
 				.ifPresent(Delivery::removeDefault);

--- a/src/main/java/com/jajaja/domain/delivery/service/DeliveryQueryService.java
+++ b/src/main/java/com/jajaja/domain/delivery/service/DeliveryQueryService.java
@@ -1,0 +1,9 @@
+package com.jajaja.domain.delivery.service;
+
+import com.jajaja.domain.delivery.dto.DeliveryResponseDto;
+
+import java.util.List;
+
+public interface DeliveryQueryService {
+	List<DeliveryResponseDto> getDeliveriesByMemberId(Long memberId);
+}

--- a/src/main/java/com/jajaja/domain/delivery/service/DeliveryQueryServiceImpl.java
+++ b/src/main/java/com/jajaja/domain/delivery/service/DeliveryQueryServiceImpl.java
@@ -7,14 +7,12 @@ import com.jajaja.domain.member.repository.MemberRepository;
 import com.jajaja.global.apiPayload.code.status.ErrorStatus;
 import com.jajaja.global.apiPayload.exception.handler.DeliveryHandler;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.stream.Collectors;
 
-@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)

--- a/src/main/java/com/jajaja/domain/delivery/service/DeliveryQueryServiceImpl.java
+++ b/src/main/java/com/jajaja/domain/delivery/service/DeliveryQueryServiceImpl.java
@@ -1,0 +1,36 @@
+package com.jajaja.domain.delivery.service;
+
+import com.jajaja.domain.delivery.dto.DeliveryResponseDto;
+import com.jajaja.domain.delivery.repository.DeliveryRepository;
+import com.jajaja.domain.member.entity.Member;
+import com.jajaja.domain.member.repository.MemberRepository;
+import com.jajaja.global.apiPayload.code.status.ErrorStatus;
+import com.jajaja.global.apiPayload.exception.handler.DeliveryHandler;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class DeliveryQueryServiceImpl  implements DeliveryQueryService {
+	
+	private final DeliveryRepository deliveryRepository;
+	private final MemberRepository memberRepository;
+	
+	@Override
+	public List<DeliveryResponseDto> getDeliveriesByMemberId(Long memberId) {
+		Member member = memberRepository.findById(memberId).orElseThrow(
+				() -> new DeliveryHandler(ErrorStatus.MEMBER_NOT_FOUND)
+		);
+		
+		return deliveryRepository.findAllByMember(member).stream()
+				.map(DeliveryResponseDto::of)
+				.collect(Collectors.toList());
+	}
+}

--- a/src/main/java/com/jajaja/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/jajaja/global/apiPayload/code/status/ErrorStatus.java
@@ -32,8 +32,7 @@ public enum ErrorStatus implements BaseErrorCode {
     
     // DELIVERY 관련 에러
     DELIVERY_NOT_FOUND(HttpStatus.BAD_REQUEST, "DELIVERY4001", "배송지가 없습니다."),
-    DELIVERY_ALREADY_DEFAULT(HttpStatus.BAD_REQUEST, "DELIVERY4002", "이미 기본 배송지가 존재합니다."),
-    DELIVERY_MEMBER_NOT_MATCH(HttpStatus.BAD_REQUEST, "DELIVERY4003", "배송지의 주인과 현재 로그인한 사용자가 다릅니다."),
+    DELIVERY_MEMBER_NOT_MATCH(HttpStatus.BAD_REQUEST, "DELIVERY4002", "배송지의 주인과 현재 로그인한 사용자가 다릅니다."),
 
     // BUSINESS CATEGORY 관련 에러
     BUSINESS_CATEGORY_NOT_FOUND(HttpStatus.BAD_REQUEST, "CATEGORY4001", "업종이 존재하지 않습니다."),

--- a/src/main/java/com/jajaja/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/jajaja/global/apiPayload/code/status/ErrorStatus.java
@@ -31,7 +31,9 @@ public enum ErrorStatus implements BaseErrorCode {
     MEMBER_REQUIRED(HttpStatus.BAD_REQUEST, "MEMBER4003", "회원만 사용할 수 있는 기능입니다."),
     
     // DELIVERY 관련 에러
-    DELIVERY_ALREADY_DEFAULT(HttpStatus.BAD_REQUEST, "DELIVERY4001", "이미 기본 배송지가 존재합니다."),
+    DELIVERY_NOT_FOUND(HttpStatus.BAD_REQUEST, "DELIVERY4001", "배송지가 없습니다."),
+    DELIVERY_ALREADY_DEFAULT(HttpStatus.BAD_REQUEST, "DELIVERY4002", "이미 기본 배송지가 존재합니다."),
+    DELIVERY_MEMBER_NOT_MATCH(HttpStatus.BAD_REQUEST, "DELIVERY4003", "배송지의 주인과 현재 로그인한 사용자가 다릅니다."),
 
     // BUSINESS CATEGORY 관련 에러
     BUSINESS_CATEGORY_NOT_FOUND(HttpStatus.BAD_REQUEST, "CATEGORY4001", "업종이 존재하지 않습니다."),

--- a/src/main/java/com/jajaja/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/jajaja/global/apiPayload/code/status/ErrorStatus.java
@@ -29,6 +29,9 @@ public enum ErrorStatus implements BaseErrorCode {
     MEMBER_NOT_FOUND(HttpStatus.BAD_REQUEST, "MEMBER4001", "사용자가 없습니다."),
     MEMBER_BUSINESS_CATEGORY_NOT_FOUND(HttpStatus.BAD_REQUEST, "MEMBERBUSINESS4002", "사용자의 업종 정보가 없습니다."),
     MEMBER_REQUIRED(HttpStatus.BAD_REQUEST, "MEMBER4003", "회원만 사용할 수 있는 기능입니다."),
+    
+    // DELIVERY 관련 에러
+    DELIVERY_ALREADY_DEFAULT(HttpStatus.BAD_REQUEST, "DELIVERY4001", "이미 기본 배송지가 존재합니다."),
 
     // BUSINESS CATEGORY 관련 에러
     BUSINESS_CATEGORY_NOT_FOUND(HttpStatus.BAD_REQUEST, "CATEGORY4001", "업종이 존재하지 않습니다."),

--- a/src/main/java/com/jajaja/global/apiPayload/exception/handler/DeliveryHandler.java
+++ b/src/main/java/com/jajaja/global/apiPayload/exception/handler/DeliveryHandler.java
@@ -1,0 +1,10 @@
+package com.jajaja.global.apiPayload.exception.handler;
+
+import com.jajaja.global.apiPayload.code.BaseErrorCode;
+import com.jajaja.global.apiPayload.exception.GeneralException;
+
+public class DeliveryHandler extends GeneralException {
+	public DeliveryHandler(BaseErrorCode errorCode) {
+		super(errorCode);
+	}
+}


### PR DESCRIPTION
## 📋 작업 내용
- 배송지 관련 API 구현

## 🎯 관련 이슈
- closes #48 

## 📝 변경 사항
- [x] 배송지 목록 조회 API 구현
- [x] 배송지 추가 API 구현
- [x] 배송지 수정 API 구현
- [x] 배송지 삭제 API 구현
- [x] 이미 기본 배송지가 있을 경우 해당 배송지의 기본 배송지 설정을 제거하고 현 배송지에 기본 배송지 설정 진행

## 📸 스크린샷 (선택사항)

## ✅ 체크리스트
- [x] 코드 컨벤션 준수
- [x] 주석 작성
- [x] 문서 업데이트
- [x] 리뷰어 지정

## 💬 리뷰어에게 하고 싶은 말
