### PR TITLE
✨ feat: 작성한 리뷰 조회/삭제 API

### DIFF
--- a/src/main/java/com/jajaja/domain/product/controller/ProductController.java
+++ b/src/main/java/com/jajaja/domain/product/controller/ProductController.java
@@ -41,7 +41,7 @@ public class ProductController {
 
     @Operation(
             summary = "하위 카테고리 상품 목록 조회 API | by 루비/이송미",
-            description = "정렬 기준에 따라 상품을 무한스크롤 방식으로 조회합니다."
+            description = "상품을 정렬 기준(인기순 | 최신상품순 | 낮은 가격 순 | 리뷰 많은 순)에 따라 조회합니다."
     )
     @GetMapping("/categories/{subcategoryId}/products")
     public ApiResponse<CategoryProductListResponseDto> getProductsBySubCategory(

--- a/src/main/java/com/jajaja/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/jajaja/domain/review/controller/ReviewController.java
@@ -109,6 +109,19 @@ public class ReviewController {
     }
 
     @Operation(
+            summary = "리뷰 삭제 API | by 루비/이송미",
+            description = "본인이 작성한 리뷰를 삭제합니다."
+    )
+    @DeleteMapping("/{reviewId}")
+    public ApiResponse<Void> deleteReview(
+            @Auth Long memberId,
+            @PathVariable Long reviewId
+    ) {
+        reviewCommandService.deleteReview(memberId, reviewId);
+        return ApiResponse.onSuccess(null);
+    }
+
+    @Operation(
             summary = "내가 작성한 리뷰 목록 조회 API | by 루비/이송미",
             description = "로그인한 사용자가 작성한 리뷰 목록을 작성일 내림차순으로 조회합니다."
     )

--- a/src/main/java/com/jajaja/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/jajaja/domain/review/controller/ReviewController.java
@@ -108,4 +108,18 @@ public class ReviewController {
         return ApiResponse.onSuccess(new ReviewCreateResponseDto(reviewId));
     }
 
+    @Operation(
+            summary = "내가 작성한 리뷰 목록 조회 API | by 루비/이송미",
+            description = "로그인한 사용자가 작성한 리뷰 목록을 작성일 내림차순으로 조회합니다."
+    )
+    @GetMapping("/me")
+    public ApiResponse<PagingReviewListResponseDto> getMyReviews(
+            @Auth Long memberId,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "5") int size
+    ) {
+        PagingReviewListResponseDto responseDto = reviewQueryService.getMyReviewList(memberId, page, size);
+        return ApiResponse.onSuccess(responseDto);
+    }
+
 }

--- a/src/main/java/com/jajaja/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/jajaja/domain/review/controller/ReviewController.java
@@ -93,7 +93,7 @@ public class ReviewController {
             description = """
                           구매한 상품에 대해 리뷰를 추가합니다.
 
-                          - 별점, 내용, 사진(최대 6장)을 포함할 수 있습니다.
+                          - 별점, 내용, 사진(최대 5장)을 포함할 수 있습니다.
                           - 이미지는 S3 Presigned URL을 통해 업로드한 후,
                             해당 key 값을 imageKeys로 전달해주세요.
                           """

--- a/src/main/java/com/jajaja/domain/review/entity/Review.java
+++ b/src/main/java/com/jajaja/domain/review/entity/Review.java
@@ -48,4 +48,8 @@ public class Review extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "product_option_id")
     private ProductOption productOption;
+
+    public void softDelete() {
+        this.deletedAt = LocalDateTime.now();
+    }
 }

--- a/src/main/java/com/jajaja/domain/review/repository/ReviewRepositoryCustom.java
+++ b/src/main/java/com/jajaja/domain/review/repository/ReviewRepositoryCustom.java
@@ -12,4 +12,5 @@ public interface ReviewRepositoryCustom {
     List<String> findTop6ReviewImageUrlsByProductId(Long productId);
     Page<ReviewItemDto> findPageByProductIdOrderByCreatedAt(Long productId, int page, int size);
     Page<ReviewItemDto> findPageByProductIdOrderByLikeCount(Long productId, int page, int size);
+    Page<ReviewItemDto> findPageByMemberIdOrderByCreatedAt(Long memberId, int page, int size);
 }

--- a/src/main/java/com/jajaja/domain/review/service/ReviewCommandService.java
+++ b/src/main/java/com/jajaja/domain/review/service/ReviewCommandService.java
@@ -4,4 +4,5 @@ import com.jajaja.domain.review.dto.request.ReviewCreateRequestDto;
 
 public interface ReviewCommandService {
     Long createReview(Long memberId, Long productId, ReviewCreateRequestDto requestDto);
+    void deleteReview(Long memberId, Long reviewId);
 }

--- a/src/main/java/com/jajaja/domain/review/service/ReviewCommandServiceImpl.java
+++ b/src/main/java/com/jajaja/domain/review/service/ReviewCommandServiceImpl.java
@@ -55,7 +55,7 @@ public class ReviewCommandServiceImpl implements ReviewCommandService {
         // 이미지 처리
         List<String> imageKeys = dto.imageKeys();
         if (imageKeys != null && !imageKeys.isEmpty()) {
-            if (imageKeys.size() > 6) {
+            if (imageKeys.size() > 5) {
                 throw new BadRequestException(ErrorStatus.REVIEW_TOO_MANY_IMAGES);
             }
 

--- a/src/main/java/com/jajaja/domain/review/service/ReviewCommandServiceImpl.java
+++ b/src/main/java/com/jajaja/domain/review/service/ReviewCommandServiceImpl.java
@@ -78,4 +78,19 @@ public class ReviewCommandServiceImpl implements ReviewCommandService {
         return review.getId();
     }
 
+    @Override
+    public void deleteReview(Long memberId, Long reviewId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new UnauthorizedException(ErrorStatus.MEMBER_NOT_FOUND));
+
+        Review review = reviewRepository.findById(reviewId)
+                .orElseThrow(() -> new BadRequestException(ErrorStatus.REVIEW_NOT_FOUND));
+
+        if (!review.getMember().getId().equals(memberId)) {
+            throw new UnauthorizedException(ErrorStatus.REVIEW_UNAUTHORIZED);
+        }
+
+        review.softDelete();
+    }
+
 }

--- a/src/main/java/com/jajaja/domain/review/service/ReviewQueryService.java
+++ b/src/main/java/com/jajaja/domain/review/service/ReviewQueryService.java
@@ -9,4 +9,5 @@ public interface ReviewQueryService {
     ReviewBriefResponseDto getReviewBriefInfo(Long productId);
     PagingReviewListResponseDto getReviewList(Long userId, Long productId, String sort, int page, int size);
     PagingReviewImageListResponseDto getReviewImageList(Long productId, String sort, int page, int size);
+    PagingReviewListResponseDto getMyReviewList(Long memberId, int page, int size);
 }

--- a/src/main/java/com/jajaja/domain/review/service/ReviewQueryServiceImpl.java
+++ b/src/main/java/com/jajaja/domain/review/service/ReviewQueryServiceImpl.java
@@ -105,4 +105,26 @@ public class ReviewQueryServiceImpl implements ReviewQueryService {
         return PagingReviewImageListResponseDto.of(reviewImageListPage, reviewImageListDtos);
     }
 
+    @Override
+    public PagingReviewListResponseDto getMyReviewList(Long memberId, int page, int size) {
+        Page<ReviewItemDto> reviewItemPage = reviewRepository.findPageByMemberIdOrderByCreatedAt(memberId, page, size);
+
+        List<Integer> reviewIds = reviewItemPage.stream()
+                .map(ReviewItemDto::id)
+                .toList();
+
+        Map<Integer, List<String>> imageUrlsMap = reviewImageRepository
+                .findTop6ImageUrlsGroupedByReviewIds(reviewIds);
+
+        List<ReviewListDto> reviewDtos = reviewItemPage.stream()
+                .map(dto -> new ReviewListDto(
+                        dto,
+                        true,
+                        imageUrlsMap.getOrDefault(dto.id(), List.of())
+                ))
+                .toList();
+
+        return PagingReviewListResponseDto.of(reviewItemPage, reviewDtos);
+    }
+
 }

--- a/src/main/java/com/jajaja/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/jajaja/global/apiPayload/code/status/ErrorStatus.java
@@ -75,6 +75,7 @@ public enum ErrorStatus implements BaseErrorCode {
     REVIEW_NOT_FOUND(HttpStatus.BAD_REQUEST, "REVIEW4001", "리뷰가 없습니다."),
     REVIEW_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "REVIEW4002", "해당 상품에 대한 리뷰를 작성할 수 없습니다."),
     REVIEW_TOO_MANY_IMAGES(HttpStatus.BAD_REQUEST, "REVIEW4003", "이미지는 최대 6장까지 등록할 수 있습니다."),
+    REVIEW_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "REVIEW4004", "본인의 리뷰만 삭제할 수 있습니다."),
 
     // NOTIFICATION 관련 에러
     NOTIFICATION_NOT_FOUND(HttpStatus.BAD_REQUEST, "NOTIFICATION4001", "알림이 없습니다."),

--- a/src/main/java/com/jajaja/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/jajaja/global/apiPayload/code/status/ErrorStatus.java
@@ -74,7 +74,7 @@ public enum ErrorStatus implements BaseErrorCode {
     // REVIEW 관련 에러
     REVIEW_NOT_FOUND(HttpStatus.BAD_REQUEST, "REVIEW4001", "리뷰가 없습니다."),
     REVIEW_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "REVIEW4002", "해당 상품에 대한 리뷰를 작성할 수 없습니다."),
-    REVIEW_TOO_MANY_IMAGES(HttpStatus.BAD_REQUEST, "REVIEW4003", "이미지는 최대 6장까지 등록할 수 있습니다."),
+    REVIEW_TOO_MANY_IMAGES(HttpStatus.BAD_REQUEST, "REVIEW4003", "이미지는 최대 5장까지 등록할 수 있습니다."),
     REVIEW_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "REVIEW4004", "본인의 리뷰만 삭제할 수 있습니다."),
 
     // NOTIFICATION 관련 에러


### PR DESCRIPTION
## 📋 작업 내용
- 작성한 리뷰를 조회 & 삭제하는 API를 구현했습니다.

## 🎯 관련 이슈
- closes #57 

## 📝 변경 사항
- [x] 내가 작성한 리뷰 조회 API 구현
- [x] 내가 작성한 리뷰 삭제 API 구현
- [ ] 리뷰 추가 시 최대 등록 가능한 이미지 6장 -> 5장으로 수정

## 📸 스크린샷 (선택사항)
- 리뷰 조회
<img width="854" height="370" alt="리뷰 조회" src="https://github.com/user-attachments/assets/3631c01f-4f1c-4264-808c-90b5d419f0ef" />

- 리뷰 삭제
<img width="848" height="286" alt="리뷰 삭제" src="https://github.com/user-attachments/assets/534bd289-9247-44b0-a185-eb8994d5f0ea" />

## ✅ 체크리스트
- [x] 코드 컨벤션 준수
- [x] 주석 작성
- [x] 문서 업데이트
- [x] 리뷰어 지정

## 💬 리뷰어에게 하고 싶은 말

