### PR TITLE
✨ feat: 포인트 관련 API, 메서드

### DIFF
--- a/src/main/java/com/jajaja/domain/notification/entity/enums/NotificationType.java
+++ b/src/main/java/com/jajaja/domain/notification/entity/enums/NotificationType.java
@@ -3,5 +3,6 @@ package com.jajaja.domain.notification.entity.enums;
 public enum NotificationType {
     MATCHING,     // 팀 매칭 관련
     DELIVERY,     // 배송 관련
-    COUPON_AD     // 쿠폰/광고 관련
+    COUPON_AD,    // 쿠폰/광고 관련
+    POINT_EXPIRED // 포인트 만료
 }

--- a/src/main/java/com/jajaja/domain/point/controller/PointController.java
+++ b/src/main/java/com/jajaja/domain/point/controller/PointController.java
@@ -1,0 +1,87 @@
+package com.jajaja.domain.point.controller;
+
+import com.jajaja.domain.point.dto.response.PagingPointHistoryResponseDto;
+import com.jajaja.domain.point.dto.response.PointBalanceResponseDto;
+import com.jajaja.domain.point.service.PointCommandService;
+import com.jajaja.domain.point.service.PointQueryService;
+import com.jajaja.global.apiPayload.ApiResponse;
+import com.jajaja.global.config.security.annotation.Auth;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/points")
+@Tag(name = "Point", description = "포인트 API")
+public class PointController {
+
+    private final PointQueryService pointQueryService;
+    private final PointCommandService pointCommandService;
+
+    @Operation(
+            summary = "포인트 잔액 조회 | by 지안/윤진수",
+            description = "로그인한 사용자의 포인트 잔액을 조회합니다."
+    )
+    @GetMapping("/balance")
+    public ApiResponse<PointBalanceResponseDto> getPointBalance(@Auth Long memberId) {
+        PointBalanceResponseDto pointBalanceResponseDto = pointQueryService.getPointBalance(memberId);
+        return ApiResponse.onSuccess(pointBalanceResponseDto);
+    }
+
+    @Operation(
+            summary = "포인트 사용 내역 조회 | by 지안/윤진수",
+            description = "로그인한 사용자의 포인트 사용 내역을 최신순으로 조회합니다."
+    )
+    @GetMapping("/history")
+    public ApiResponse<PagingPointHistoryResponseDto> getPointHistory(@Auth Long memberId, Pageable pageable) {
+        PagingPointHistoryResponseDto pagingPointHistoryResponseDto = pointQueryService.getPointHistory(memberId, pageable);
+        return ApiResponse.onSuccess(pagingPointHistoryResponseDto);
+    }
+
+    @Operation(
+            summary = "포인트 사용(테스트용, 연동 X) | by 지안/윤진수",
+            description = "로그인한 사용자가 특정 주문 상품에 대해 포인트를 사용합니다.  \n" +
+                    "사용할 포인트 금액과 주문 상품 ID를 입력해야 합니다."
+    )
+    @PostMapping("/use/{amount}/orderProducts/{orderProductId}")
+    public ApiResponse<?> usePoints(@Auth Long memberId, @PathVariable int amount, @PathVariable long orderProductId) {
+        pointCommandService.usePoints(memberId, amount, orderProductId);
+        return ApiResponse.onSuccess(null);
+    }
+
+    @Operation(
+            summary = "리뷰 작성 후 반품(테스트용, 연동 X) | by 지안/윤진수",
+            description = "리뷰 포인트를 취소합니다.  \n" +
+                    "반품 시 PointCommandService.cancelReviewPoint 호출하여 사용"
+    )
+    @PostMapping("/cancel/orderProducts/{orderProductId}")
+    public ApiResponse<?> cancelReviewPoint(@PathVariable long orderProductId) {
+        pointCommandService.cancelReviewPoint(orderProductId);
+        return ApiResponse.onSuccess(null);
+    }
+
+    @Operation(
+            summary = "결제 시 사용된 포인트 환불(테스트용, 연동 X) | by 지안/윤진수",
+            description = "사용자가 사용한 포인트를 환불합니다.  \n" +
+                    "반품 시 PointCommandService.refundUsedPoints 호출하여 사용"
+    )
+    @PostMapping("/refund/orderProducts/{orderProductId}")
+    public ApiResponse<?> refundUsedPoints(@PathVariable long orderProductId) {
+        pointCommandService.refundUsedPoints(orderProductId);
+        return ApiResponse.onSuccess(null);
+    }
+
+    @Operation(
+            summary = "리뷰 작성 후 포인트 추가(테스트용, 연동 X) | by 지안/윤진수",
+            description = "리뷰 작성 후 포인트를 추가합니다.  \n" +
+                    "리뷰 작성 시 PointCommandService.addReviewPoints 호출하여 사용"
+    )
+    @PostMapping("/add/{amount}/orderProducts/{orderProductId}")
+    public ApiResponse<?> addReviewPoints(@Auth Long memberId, @PathVariable int amount, @PathVariable long orderProductId) {
+        pointCommandService.addReviewPoints(memberId, amount, orderProductId);
+        return ApiResponse.onSuccess(null);
+    }
+}

--- a/src/main/java/com/jajaja/domain/point/controller/PointController.java
+++ b/src/main/java/com/jajaja/domain/point/controller/PointController.java
@@ -7,9 +7,10 @@ import com.jajaja.domain.point.service.PointQueryService;
 import com.jajaja.global.apiPayload.ApiResponse;
 import com.jajaja.global.config.security.annotation.Auth;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -36,8 +37,15 @@ public class PointController {
             description = "로그인한 사용자의 포인트 사용 내역을 최신순으로 조회합니다."
     )
     @GetMapping("/history")
-    public ApiResponse<PagingPointHistoryResponseDto> getPointHistory(@Auth Long memberId, Pageable pageable) {
-        PagingPointHistoryResponseDto pagingPointHistoryResponseDto = pointQueryService.getPointHistory(memberId, pageable);
+    public ApiResponse<PagingPointHistoryResponseDto> getPointHistory(
+            @Auth Long memberId,
+
+            @Parameter(description = "페이지 번호 (0부터 시작)", example = "0")
+            @RequestParam(defaultValue = "0") int page,
+
+            @Parameter(description = "페이지 크기", example = "5")
+            @RequestParam(defaultValue = "5") int size) {
+        PagingPointHistoryResponseDto pagingPointHistoryResponseDto = pointQueryService.getPointHistory(memberId, PageRequest.of(page, size));
         return ApiResponse.onSuccess(pagingPointHistoryResponseDto);
     }
 

--- a/src/main/java/com/jajaja/domain/point/dto/response/PagingPointHistoryResponseDto.java
+++ b/src/main/java/com/jajaja/domain/point/dto/response/PagingPointHistoryResponseDto.java
@@ -1,0 +1,23 @@
+package com.jajaja.domain.point.dto.response;
+
+import com.jajaja.domain.point.entity.Point;
+import com.jajaja.global.apiPayload.PageResponse;
+import lombok.Builder;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+
+@Builder
+public record PagingPointHistoryResponseDto(
+        PageResponse page,
+        int pointBalance,
+        List<PointHistoryDto> pointHistories
+) {
+    public static PagingPointHistoryResponseDto of(Page<Point> pointPage, int pointBalance, List<PointHistoryDto> pointHistoryDtos) {
+        return PagingPointHistoryResponseDto.builder()
+                .page(PageResponse.from(pointPage))
+                .pointBalance(pointBalance)
+                .pointHistories(pointHistoryDtos)
+                .build();
+    }
+}

--- a/src/main/java/com/jajaja/domain/point/dto/response/PointBalanceResponseDto.java
+++ b/src/main/java/com/jajaja/domain/point/dto/response/PointBalanceResponseDto.java
@@ -1,0 +1,9 @@
+package com.jajaja.domain.point.dto.response;
+
+public record PointBalanceResponseDto(
+        int balance
+) {
+    public static PointBalanceResponseDto from(int balance) {
+        return new PointBalanceResponseDto(balance);
+    }
+}

--- a/src/main/java/com/jajaja/domain/point/dto/response/PointHistoryDto.java
+++ b/src/main/java/com/jajaja/domain/point/dto/response/PointHistoryDto.java
@@ -1,0 +1,31 @@
+package com.jajaja.domain.point.dto.response;
+
+import com.jajaja.domain.point.entity.Point;
+import com.jajaja.domain.point.entity.enums.PointType;
+import lombok.Builder;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Builder
+public record PointHistoryDto(
+        long id,
+        long orderId,
+        PointType type,
+        String productName,
+        int amount,
+        LocalDate expiresAt,
+        LocalDateTime createdAt
+) {
+    public static PointHistoryDto from(Point point) {
+        return PointHistoryDto.builder()
+                .id(point.getId())
+                .orderId(point.getOrderProduct().getOrder().getId())
+                .type(point.getType())
+                .productName(point.getOrderProduct().getProduct().getName())
+                .amount(point.getAmount())
+                .expiresAt(point.getExpiresAt())
+                .createdAt(point.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/jajaja/domain/point/entity/Point.java
+++ b/src/main/java/com/jajaja/domain/point/entity/Point.java
@@ -1,13 +1,15 @@
 package com.jajaja.domain.point.entity;
 
-import com.jajaja.domain.order.entity.Order;
 import com.jajaja.domain.member.entity.Member;
+import com.jajaja.domain.order.entity.OrderProduct;
 import com.jajaja.domain.point.entity.enums.PointType;
+import com.jajaja.global.apiPayload.code.status.ErrorStatus;
+import com.jajaja.global.apiPayload.exception.custom.BadRequestException;
 import com.jajaja.global.common.domain.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 
 @Entity
 @Getter
@@ -28,13 +30,27 @@ public class Point extends BaseEntity {
     private Integer amount;
 
     @Column
-    private LocalDateTime expiresAt;
+    private Integer usedAmount;
+
+    @Column
+    private LocalDate expiresAt;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "order_id")
-    private Order order;
+    @JoinColumn(name = "order_product_id")
+    private OrderProduct orderProduct;
+
+    public int getAvailableAmount() {
+        return amount - (usedAmount != null ? usedAmount : 0);
+    }
+
+    public void use(int amountToUse) {
+        if (getAvailableAmount() < amountToUse) {
+            throw new BadRequestException(ErrorStatus.INSUFFICIENT_POINT);
+        }
+        this.usedAmount += amountToUse;
+    }
 }

--- a/src/main/java/com/jajaja/domain/point/entity/enums/PointType.java
+++ b/src/main/java/com/jajaja/domain/point/entity/enums/PointType.java
@@ -4,5 +4,6 @@ public enum PointType {
     REVIEW,
     USE,
     EXPIRED,
-    CANCEL
+    CANCEL,
+    REFUND
 }

--- a/src/main/java/com/jajaja/domain/point/repository/PointRepository.java
+++ b/src/main/java/com/jajaja/domain/point/repository/PointRepository.java
@@ -1,0 +1,27 @@
+package com.jajaja.domain.point.repository;
+
+import com.jajaja.domain.order.entity.OrderProduct;
+import com.jajaja.domain.point.entity.Point;
+import com.jajaja.domain.point.entity.enums.PointType;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface PointRepository extends JpaRepository<Point, Integer>, PointRepositoryCustom {
+
+    @Query("""
+                SELECT COALESCE(SUM(
+                    CASE
+                        WHEN p.type IN ('REVIEW', 'REFUND') THEN p.amount
+                        WHEN p.type IN ('USE', 'EXPIRED', 'CANCEL') THEN -p.amount
+                    END
+                ), 0)
+                FROM Point p
+                WHERE p.member.id = :memberId
+            """)
+    int findPointBalanceByMemberId(@Param("memberId") Long memberId);
+
+    boolean existsByTypeAndOrderProduct(PointType type, OrderProduct orderProduct);
+
+
+}

--- a/src/main/java/com/jajaja/domain/point/repository/PointRepositoryCustom.java
+++ b/src/main/java/com/jajaja/domain/point/repository/PointRepositoryCustom.java
@@ -1,0 +1,22 @@
+package com.jajaja.domain.point.repository;
+
+import com.jajaja.domain.point.entity.Point;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+public interface PointRepositoryCustom {
+
+    Page<Point> findByMemberId(Long memberId, Pageable pageable);
+
+    List<Point> findExpiringPoints();
+
+    List<Point> findValidReviewPointsOrderedByOldest(Long memberId, LocalDate today);
+
+    Optional<Point> findReviewPointByOrderProductId(Long orderProductId);
+
+    Optional<Point> findUsePointByOrderProductId(Long orderProductId);
+}

--- a/src/main/java/com/jajaja/domain/point/repository/PointRepositoryImpl.java
+++ b/src/main/java/com/jajaja/domain/point/repository/PointRepositoryImpl.java
@@ -1,0 +1,128 @@
+package com.jajaja.domain.point.repository;
+
+import com.jajaja.domain.order.entity.QOrder;
+import com.jajaja.domain.order.entity.QOrderProduct;
+import com.jajaja.domain.point.entity.Point;
+import com.jajaja.domain.point.entity.QPoint;
+import com.jajaja.domain.point.entity.enums.PointType;
+import com.jajaja.domain.product.entity.QProduct;
+import com.jajaja.domain.team.entity.QTeam;
+import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class PointRepositoryImpl implements PointRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Page<Point> findByMemberId(Long memberId, Pageable pageable) {
+        QPoint point = QPoint.point;
+        QOrderProduct orderProduct = QOrderProduct.orderProduct;
+        QOrder order = QOrder.order;
+        QProduct product = QProduct.product;
+        QTeam team = QTeam.team;
+
+        List<Long> pointIds = queryFactory
+                .select(point.id)
+                .from(point)
+                .where(point.member.id.eq(memberId))
+                .orderBy(point.createdAt.desc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        if (pointIds.isEmpty()) {
+            return Page.empty(pageable);
+        }
+
+        List<Point> points = queryFactory
+                .selectFrom(point)
+                .distinct()
+                .leftJoin(point.orderProduct, orderProduct).fetchJoin()
+                .leftJoin(orderProduct.order, order).fetchJoin()
+                .leftJoin(orderProduct.product, product).fetchJoin()
+                .leftJoin(order.team, team).fetchJoin()
+                .where(point.id.in(pointIds))
+                .orderBy(point.createdAt.desc())
+                .fetch();
+
+        long count = Optional.ofNullable(
+                queryFactory.select(point.count()).from(point).where(point.member.id.eq(memberId)).fetchOne()
+        ).orElse(0L);
+
+        return new PageImpl<>(points, pageable, count);
+    }
+
+    @Override
+    public List<Point> findExpiringPoints() {
+        QPoint point = QPoint.point;
+        QPoint subPoint = new QPoint("subPoint");
+
+        return queryFactory
+                .selectFrom(point)
+                .where(
+                        point.type.eq(PointType.REVIEW),
+                        point.usedAmount.lt(point.amount),
+                        point.expiresAt.lt(LocalDate.now()),
+                        point.orderProduct.isNotNull(),
+                        JPAExpressions
+                                .selectOne()
+                                .from(subPoint)
+                                .where(
+                                        subPoint.type.eq(PointType.EXPIRED),
+                                        subPoint.orderProduct.eq(point.orderProduct)
+                                )
+                                .notExists()
+                )
+                .fetch();
+    }
+
+    @Override
+    public List<Point> findValidReviewPointsOrderedByOldest(Long memberId, LocalDate today) {
+        QPoint point = QPoint.point;
+
+        return queryFactory
+                .selectFrom(point)
+                .where(
+                        point.member.id.eq(memberId),
+                        point.type.eq(PointType.REVIEW),
+                        point.usedAmount.lt(point.amount),
+                        point.expiresAt.after(today)
+                )
+                .orderBy(point.createdAt.asc())
+                .fetch();
+    }
+
+    @Override
+    public Optional<Point> findReviewPointByOrderProductId(Long orderProductId) {
+        QPoint point = QPoint.point;
+        return Optional.ofNullable(queryFactory
+                .selectFrom(point)
+                .where(
+                        point.orderProduct.id.eq(orderProductId),
+                        point.type.eq(PointType.REVIEW))
+                .fetchOne());
+    }
+
+    @Override
+    public Optional<Point> findUsePointByOrderProductId(Long orderProductId) {
+        QPoint point = QPoint.point;
+        return Optional.ofNullable(queryFactory
+                .selectFrom(point)
+                .where(
+                        point.orderProduct.id.eq(orderProductId),
+                        point.type.eq(PointType.USE)
+                ).fetchOne());
+    }
+}

--- a/src/main/java/com/jajaja/domain/point/repository/PointRepositoryImpl.java
+++ b/src/main/java/com/jajaja/domain/point/repository/PointRepositoryImpl.java
@@ -25,6 +25,9 @@ public class PointRepositoryImpl implements PointRepositoryCustom {
 
     private final JPAQueryFactory queryFactory;
 
+    /**
+     * 포인트 기록 페이징 조회
+     */
     @Override
     public Page<Point> findByMemberId(Long memberId, Pageable pageable) {
         QPoint point = QPoint.point;
@@ -64,6 +67,9 @@ public class PointRepositoryImpl implements PointRepositoryCustom {
         return new PageImpl<>(points, pageable, count);
     }
 
+    /**
+     * 만료된 포인트 찾기 - 스케줄러에서 사용
+     */
     @Override
     public List<Point> findExpiringPoints() {
         QPoint point = QPoint.point;
@@ -88,6 +94,9 @@ public class PointRepositoryImpl implements PointRepositoryCustom {
                 .fetch();
     }
 
+    /**
+     * 유효한 포인트 조회 - 리뷰 포인트 중 사용되지 않은 포인트를 가장 오래된 순서로 조회
+     */
     @Override
     public List<Point> findValidReviewPointsOrderedByOldest(Long memberId, LocalDate today) {
         QPoint point = QPoint.point;
@@ -104,6 +113,9 @@ public class PointRepositoryImpl implements PointRepositoryCustom {
                 .fetch();
     }
 
+    /**
+     * 리뷰 포인트 조회 - 특정 주문 상품에 대한 "REVIEW 포인트" 조회
+     */
     @Override
     public Optional<Point> findReviewPointByOrderProductId(Long orderProductId) {
         QPoint point = QPoint.point;
@@ -115,6 +127,9 @@ public class PointRepositoryImpl implements PointRepositoryCustom {
                 .fetchOne());
     }
 
+    /**
+     * 사용된 포인트 조회 - 특정 주문 상품에 대한 "USE 포인트" 조회
+     */
     @Override
     public Optional<Point> findUsePointByOrderProductId(Long orderProductId) {
         QPoint point = QPoint.point;

--- a/src/main/java/com/jajaja/domain/point/service/PointCommandService.java
+++ b/src/main/java/com/jajaja/domain/point/service/PointCommandService.java
@@ -1,0 +1,12 @@
+package com.jajaja.domain.point.service;
+
+public interface PointCommandService {
+
+    void usePoints(Long memberId, int amountToUse, long orderProductId);
+
+    void addReviewPoints(Long memberId, int amount, long orderProductId);
+
+    void cancelReviewPoint(Long orderProductId);
+
+    void refundUsedPoints(Long orderProductId);
+}

--- a/src/main/java/com/jajaja/domain/point/service/PointCommandServiceImpl.java
+++ b/src/main/java/com/jajaja/domain/point/service/PointCommandServiceImpl.java
@@ -1,0 +1,110 @@
+package com.jajaja.domain.point.service;
+
+import com.jajaja.domain.member.entity.Member;
+import com.jajaja.domain.member.repository.MemberRepository;
+import com.jajaja.domain.order.entity.OrderProduct;
+import com.jajaja.domain.order.repository.OrderProductRepository;
+import com.jajaja.domain.point.entity.Point;
+import com.jajaja.domain.point.entity.enums.PointType;
+import com.jajaja.domain.point.repository.PointRepository;
+import com.jajaja.global.apiPayload.code.status.ErrorStatus;
+import com.jajaja.global.apiPayload.exception.custom.BadRequestException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class PointCommandServiceImpl implements PointCommandService {
+
+    private final PointRepository pointRepository;
+    private final MemberRepository memberRepository;
+    private final OrderProductRepository orderProductRepository;
+
+    @Override
+    public void usePoints(Long memberId, int amountToUse, long orderProductId) {
+        List<Point> points = pointRepository.findValidReviewPointsOrderedByOldest(memberId, LocalDate.now());
+        int remainingToUse = amountToUse;
+        for (Point point : points) {
+            int canUse = point.getAvailableAmount();
+            if (canUse == 0) continue;
+            int useNow = Math.min(remainingToUse, canUse);
+            point.use(useNow);
+            remainingToUse -= useNow;
+            if (remainingToUse <= 0) break;
+        }
+        if (remainingToUse > 0) {
+            throw new BadRequestException(ErrorStatus.INSUFFICIENT_POINT);
+        }
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new BadRequestException(ErrorStatus.MEMBER_NOT_FOUND));
+        OrderProduct orderProduct = orderProductRepository.findById(orderProductId)
+                .orElseThrow(() -> new BadRequestException(ErrorStatus.ORDER_PRODUCT_NOT_FOUND));
+        Point usedPoint = Point.builder()
+                .type(PointType.USE)
+                .amount(amountToUse)
+                .member(member)
+                .orderProduct(orderProduct)
+                .build();
+        pointRepository.saveAll(points);
+        pointRepository.save(usedPoint);
+    }
+
+    @Override
+    public void addReviewPoints(Long memberId, int amount, long orderProductId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new BadRequestException(ErrorStatus.MEMBER_NOT_FOUND));
+        OrderProduct orderProduct = orderProductRepository.findById(orderProductId)
+                .orElseThrow(() -> new BadRequestException(ErrorStatus.ORDER_PRODUCT_NOT_FOUND));
+        Point point = Point.builder()
+                .type(PointType.REVIEW)
+                .amount(amount)
+                .usedAmount(0)
+                // 30일 후 만료로 설정
+                .expiresAt(LocalDate.now().plusDays(30))
+                .member(member)
+                .orderProduct(orderProduct)
+                .build();
+        pointRepository.save(point);
+    }
+
+    @Override
+    public void cancelReviewPoint(Long orderProductId) {
+        Point reviewPoint = pointRepository.findReviewPointByOrderProductId(orderProductId)
+                .orElseThrow(() -> new BadRequestException(ErrorStatus.POINT_NOT_FOUND));
+        boolean alreadyCancelled = pointRepository.existsByTypeAndOrderProduct(PointType.CANCEL, reviewPoint.getOrderProduct());
+        if (alreadyCancelled) {
+            throw new BadRequestException(ErrorStatus.ALREADY_CANCELLED_POINT);
+        }
+        Point cancelPoint = Point.builder()
+                .type(PointType.CANCEL)
+                .amount(reviewPoint.getAmount())
+                .member(reviewPoint.getMember())
+                .orderProduct(reviewPoint.getOrderProduct())
+                .build();
+        pointRepository.save(cancelPoint);
+    }
+
+    @Override
+    public void refundUsedPoints(Long orderProductId) {
+        Point usePoint = pointRepository.findUsePointByOrderProductId(orderProductId)
+                .orElseThrow(() -> new BadRequestException(ErrorStatus.POINT_NOT_FOUND));
+        boolean alreadyRefunded = pointRepository.existsByTypeAndOrderProduct(PointType.REFUND, usePoint.getOrderProduct());
+        if (alreadyRefunded) {
+            throw new BadRequestException(ErrorStatus.ALREADY_REFUNDED_POINT);
+        }
+        Point refundPoint = Point.builder()
+                .type(PointType.REFUND)
+                .amount(usePoint.getAmount())
+                .member(usePoint.getMember())
+                .orderProduct(usePoint.getOrderProduct())
+                .expiresAt(usePoint.getExpiresAt())
+                .usedAmount(0)
+                .build();
+        pointRepository.save(refundPoint);
+    }
+}

--- a/src/main/java/com/jajaja/domain/point/service/PointCommandServiceImpl.java
+++ b/src/main/java/com/jajaja/domain/point/service/PointCommandServiceImpl.java
@@ -25,6 +25,12 @@ public class PointCommandServiceImpl implements PointCommandService {
     private final MemberRepository memberRepository;
     private final OrderProductRepository orderProductRepository;
 
+    /**
+     * 포인트를 사용합니다. 사용 가능한 리뷰 포인트를 찾아서 순차적으로 사용합니다.
+     * @param memberId 회원 ID
+     * @param amountToUse 사용하려는 포인트 양
+     * @param orderProductId 주문 상품 ID
+     */
     @Override
     public void usePoints(Long memberId, int amountToUse, long orderProductId) {
         List<Point> points = pointRepository.findValidReviewPointsOrderedByOldest(memberId, LocalDate.now());
@@ -54,6 +60,12 @@ public class PointCommandServiceImpl implements PointCommandService {
         pointRepository.save(usedPoint);
     }
 
+    /**
+     * 리뷰 작성 후 포인트를 추가합니다.
+     * @param memberId 회원 ID
+     * @param amount 포인트 양
+     * @param orderProductId 주문 상품 ID
+     */
     @Override
     public void addReviewPoints(Long memberId, int amount, long orderProductId) {
         Member member = memberRepository.findById(memberId)
@@ -72,6 +84,10 @@ public class PointCommandServiceImpl implements PointCommandService {
         pointRepository.save(point);
     }
 
+    /**
+     * 포인트 획득을 취소합니다.
+     * @param orderProductId 주문 상품 ID
+     */
     @Override
     public void cancelReviewPoint(Long orderProductId) {
         Point reviewPoint = pointRepository.findReviewPointByOrderProductId(orderProductId)
@@ -89,6 +105,10 @@ public class PointCommandServiceImpl implements PointCommandService {
         pointRepository.save(cancelPoint);
     }
 
+    /**
+     * 사용된 포인트를 환불합니다.
+     * @param orderProductId 주문 상품 ID
+     */
     @Override
     public void refundUsedPoints(Long orderProductId) {
         Point usePoint = pointRepository.findUsePointByOrderProductId(orderProductId)

--- a/src/main/java/com/jajaja/domain/point/service/PointQueryService.java
+++ b/src/main/java/com/jajaja/domain/point/service/PointQueryService.java
@@ -1,0 +1,12 @@
+package com.jajaja.domain.point.service;
+
+import com.jajaja.domain.point.dto.response.PagingPointHistoryResponseDto;
+import com.jajaja.domain.point.dto.response.PointBalanceResponseDto;
+import org.springframework.data.domain.Pageable;
+
+public interface PointQueryService {
+
+    PagingPointHistoryResponseDto getPointHistory(Long memberId, Pageable pageable);
+
+    PointBalanceResponseDto getPointBalance(Long memberId);
+}

--- a/src/main/java/com/jajaja/domain/point/service/PointQueryServiceImpl.java
+++ b/src/main/java/com/jajaja/domain/point/service/PointQueryServiceImpl.java
@@ -1,0 +1,39 @@
+package com.jajaja.domain.point.service;
+
+import com.jajaja.domain.point.dto.response.PagingPointHistoryResponseDto;
+import com.jajaja.domain.point.dto.response.PointBalanceResponseDto;
+import com.jajaja.domain.point.dto.response.PointHistoryDto;
+import com.jajaja.domain.point.entity.Point;
+import com.jajaja.domain.point.repository.PointRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class PointQueryServiceImpl implements PointQueryService {
+
+    private final PointRepository pointRepository;
+
+    @Override
+    public PagingPointHistoryResponseDto getPointHistory(Long memberId, Pageable pageable) {
+        Page<Point> pointPage = pointRepository.findByMemberId(memberId, pageable);
+        List<PointHistoryDto> pointHistoryDtos = pointPage.getContent().stream()
+                .map(PointHistoryDto::from)
+                .collect(Collectors.toList());
+        int pointBalance = pointRepository.findPointBalanceByMemberId(memberId);
+        return PagingPointHistoryResponseDto.of(pointPage, pointBalance, pointHistoryDtos);
+    }
+
+    @Override
+    public PointBalanceResponseDto getPointBalance(Long memberId) {
+        int pointBalance = pointRepository.findPointBalanceByMemberId(memberId);
+        return PointBalanceResponseDto.from(pointBalance);
+    }
+}

--- a/src/main/java/com/jajaja/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/jajaja/global/apiPayload/code/status/ErrorStatus.java
@@ -83,6 +83,12 @@ public enum ErrorStatus implements BaseErrorCode {
 
     // S3 관련 에러
     INVALID_IMAGE_KEY(HttpStatus.BAD_REQUEST, "IMAGE4001", "유효하지 않은 이미지 키입니다."),
+
+    // 포인트 관련 에러
+    POINT_NOT_FOUND(HttpStatus.BAD_REQUEST, "POINT4001", "포인트가 없습니다."),
+    INSUFFICIENT_POINT(HttpStatus.BAD_REQUEST, "POINT4002", "포인트가 부족합니다."),
+    ALREADY_CANCELLED_POINT(HttpStatus.BAD_REQUEST, "POINT4003", "이미 취소된 포인트입니다."),
+    ALREADY_REFUNDED_POINT(HttpStatus.BAD_REQUEST, "POINT4004", "이미 환불된 포인트입니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/jajaja/global/scheduler/PointExpireScheduler.java
+++ b/src/main/java/com/jajaja/global/scheduler/PointExpireScheduler.java
@@ -1,0 +1,44 @@
+package com.jajaja.global.scheduler;
+
+import com.jajaja.domain.point.entity.Point;
+import com.jajaja.domain.point.entity.enums.PointType;
+import com.jajaja.domain.point.repository.PointRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PointExpireScheduler {
+
+    private final PointRepository pointRepository;
+//    private final NotificationService notificationService;
+
+    @Scheduled(cron = "0 0 0 * * *") // 매일 자정에 실행
+    @Transactional
+    public void expirePoints() {
+        log.info("[스케줄러 실행] PointExpireScheduler 시작");
+
+        List<Point> expiredPoints = pointRepository.findExpiringPoints();
+
+        log.info("만료된 포인트 수 = {}", expiredPoints.size());
+
+        for (Point point : expiredPoints) {
+            Point expiredPoint = Point.builder()
+                    .type(PointType.EXPIRED)
+                    // 남은 포인트만큼 만료(차감) 처리
+                    .amount(point.getAvailableAmount())
+                    .member(point.getMember())
+                    .orderProduct(point.getOrderProduct())
+                    .build();
+            pointRepository.save(expiredPoint);
+            // 사용자에게 포인트 만료 알림 전송? (혹은 만료 1주 전 등 사전 알림)
+//            notificationService.createNotification(new NotificationCreateRequestDto(point.getMember().getId(), NotificationType.POINT_EXPIRED, "포인트가 만료되었습니다."));
+        }
+    }
+}

--- a/src/main/java/com/jajaja/global/scheduler/PointExpireScheduler.java
+++ b/src/main/java/com/jajaja/global/scheduler/PointExpireScheduler.java
@@ -1,5 +1,8 @@
 package com.jajaja.global.scheduler;
 
+import com.jajaja.domain.notification.dto.NotificationCreateRequestDto;
+import com.jajaja.domain.notification.entity.enums.NotificationType;
+import com.jajaja.domain.notification.service.NotificationService;
 import com.jajaja.domain.point.entity.Point;
 import com.jajaja.domain.point.entity.enums.PointType;
 import com.jajaja.domain.point.repository.PointRepository;
@@ -17,7 +20,7 @@ import java.util.List;
 public class PointExpireScheduler {
 
     private final PointRepository pointRepository;
-//    private final NotificationService notificationService;
+    private final NotificationService notificationService;
 
     @Scheduled(cron = "0 0 0 * * *") // 매일 자정에 실행
     @Transactional
@@ -37,8 +40,8 @@ public class PointExpireScheduler {
                     .orderProduct(point.getOrderProduct())
                     .build();
             pointRepository.save(expiredPoint);
-            // 사용자에게 포인트 만료 알림 전송? (혹은 만료 1주 전 등 사전 알림)
-//            notificationService.createNotification(new NotificationCreateRequestDto(point.getMember().getId(), NotificationType.POINT_EXPIRED, "포인트가 만료되었습니다."));
+            // 사용자에게 포인트 만료 알림 전송
+            notificationService.createNotification(new NotificationCreateRequestDto(point.getMember().getId(), NotificationType.POINT_EXPIRED, "포인트가 만료되었습니다."));
         }
     }
 }


### PR DESCRIPTION
## 📋 작업 내용
- 포인트 관련 API, 메서드를 구현했습니다.

## 🎯 관련 이슈
- closes #65 

## 📝 변경 사항
- [x] 포인트 잔액, 기록 조회 API 추가
- [x] 포인트 사용, 추가, 취소, 환불 메서드 추가

## 📸 스크린샷 (선택사항)
- 필요한 경우 스크린샷 첨부

## ✅ 체크리스트
- [x] 코드 컨벤션 준수
- [x] 주석 작성
- [x] 문서 업데이트
- [x] 리뷰어 지정

## 💬 리뷰어에게 하고 싶은 말
### 설계 변경
- 포인트 사용 후 만료 처리를 위해 얻은 포인트에 사용한 포인트 필드를 추가했습니다.
- 반품 후 포인트 환불을 위한 유형을 추가 했습니다. (REFUND)
### 하고 싶은 말
- 포인트 관련 메서드들을 테스트를 위해 임시 API로 올렸습니다. (배포 시 삭제)
- /use: 포인트 사용, 결제 시 사용
- /cancel: 리뷰 작성을 통해 얻은 뒤 반품되는 건에 대한 포인트 획득 취소, 반품 시 사용
- /refund: 결제 시 사용된 포인트 환불, 반품에서 사용
- /add: 리뷰 작성 시 사용, 리뷰 작성에서 사용
- 포인트 만료일은 리뷰 작성일 + 30일로 일단 설정했습니다.
- 포인트 만료 처리는 매일 자정에 스케줄러를 통해 하도록 했고, 알림 전송은 일단 주석처리 해놓았습니다. 필요할까요?
- 다 하고 나니까 프로젝트나 시연 측면에서 크게 중요해보이지는 않은데 일단 하는 김에 최대한 여러 케이스 생각해서 해봤습니다