### PR TITLE
✨ feat: 구매/환불 후 판매량 업데이트 로직 추가

### DIFF
--- a/src/main/java/com/jajaja/domain/point/service/PointQueryServiceImpl.java
+++ b/src/main/java/com/jajaja/domain/point/service/PointQueryServiceImpl.java
@@ -1,10 +1,14 @@
 package com.jajaja.domain.point.service;
 
+import com.jajaja.domain.member.entity.Member;
+import com.jajaja.domain.member.repository.MemberRepository;
 import com.jajaja.domain.point.dto.response.PagingPointHistoryResponseDto;
 import com.jajaja.domain.point.dto.response.PointBalanceResponseDto;
 import com.jajaja.domain.point.dto.response.PointHistoryDto;
 import com.jajaja.domain.point.entity.Point;
 import com.jajaja.domain.point.repository.PointRepository;
+import com.jajaja.global.apiPayload.code.status.ErrorStatus;
+import com.jajaja.global.apiPayload.exception.custom.BadRequestException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -20,6 +24,7 @@ import java.util.stream.Collectors;
 public class PointQueryServiceImpl implements PointQueryService {
     
     private final PointRepository pointRepository;
+    private final MemberRepository memberRepository;
     
     @Override
     public PagingPointHistoryResponseDto getPointHistory(Long memberId, Pageable pageable) {
@@ -33,7 +38,7 @@ public class PointQueryServiceImpl implements PointQueryService {
     
     @Override
     public PointBalanceResponseDto getPointBalance(Long memberId) {
-        int pointBalance = pointRepository.findPointBalanceByMemberId(memberId);
-        return PointBalanceResponseDto.from(pointBalance);
+        Member member = memberRepository.findById(memberId).orElseThrow(() -> new BadRequestException(ErrorStatus.MEMBER_NOT_FOUND));
+        return PointBalanceResponseDto.from(member.getPoint());
     }
 }

--- a/src/main/java/com/jajaja/domain/product/repository/ProductSalesRepositoryCustom.java
+++ b/src/main/java/com/jajaja/domain/product/repository/ProductSalesRepositoryCustom.java
@@ -1,6 +1,7 @@
 package com.jajaja.domain.product.repository;
 
 import com.jajaja.domain.product.dto.projection.ProductTotalSalesDto;
+import com.jajaja.domain.product.entity.BusinessCategory;
 import com.jajaja.domain.product.entity.Product;
 import org.springframework.data.domain.Pageable;
 
@@ -11,4 +12,5 @@ public interface ProductSalesRepositoryCustom {
     List<ProductTotalSalesDto> findTopProductsByTotalSales(Pageable pageable);
     Map<Long, Long> findTotalSalesByProductIds(List<Long> productIds);
     List<Product> findProductsBySubCategoryOrderBySalesDesc(Long subcategoryId, Pageable pageable);
+    long updateSalesByProductIdAndBusinessCategory(Product product, BusinessCategory businessCategory, int count);
 }

--- a/src/main/java/com/jajaja/domain/product/repository/ProductSalesRepositoryImpl.java
+++ b/src/main/java/com/jajaja/domain/product/repository/ProductSalesRepositoryImpl.java
@@ -1,9 +1,7 @@
 package com.jajaja.domain.product.repository;
 
 import com.jajaja.domain.product.dto.projection.ProductTotalSalesDto;
-import com.jajaja.domain.product.entity.Product;
-import com.jajaja.domain.product.entity.QProduct;
-import com.jajaja.domain.product.entity.QProductSales;
+import com.jajaja.domain.product.entity.*;
 import com.querydsl.core.Tuple;
 import com.jajaja.domain.product.entity.category.QProductSubCategory;
 import com.querydsl.core.types.Projections;
@@ -80,5 +78,16 @@ public class ProductSalesRepositoryImpl implements ProductSalesRepositoryCustom 
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize() + 1)
                 .fetch();
+    }
+    
+    @Override
+    public long updateSalesByProductIdAndBusinessCategory(Product product, BusinessCategory businessCategory, int count) {
+        QProductSales ps = QProductSales.productSales;
+        
+       return queryFactory
+                .update(ps)
+                .set(ps.salesCount, ps.salesCount.add(count))
+                .where(ps.product.id.eq(product.getId()).and(ps.businessCategory.eq(businessCategory)))
+                .execute();
     }
 }


### PR DESCRIPTION
## 📋 작업 내용
- 구매/환불 후 판매량 통계 테이블 업데이트

## 🎯 관련 이슈
- closes #83 

## 📝 변경 사항
- [x] 구매 후 판매량 테이블 구매한 개수에 맞게 업데이트
- [x] 환불 후 판매량 테이블 환불한 개수에 맞게 업데이트

## 📸 스크린샷 (선택사항)
- 필요한 경우 스크린샷 첨부

## ✅ 체크리스트
- [x] 코드 컨벤션 준수
- [x] 주석 작성
- [x] 문서 업데이트
- [x] 리뷰어 지정

## 💬 리뷰어에게 하고 싶은 말

