### PR TITLE
✨ feat: 로컬 실행용 도커 이미지 생성 스크립트 추가

### DIFF
--- a/.github/workflows/ci-cd-local
+++ b/.github/workflows/ci-cd-local
@@ -1,0 +1,44 @@
+name: Build & Push Local Dev Image
+
+on:
+  push:
+    branches:
+      - main
+
+env:
+  LOCAL_IMAGE_NAME: munjji/jajaja-local
+
+jobs:
+  build-and-push-local:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v3
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Create resources directory
+        run: mkdir -p ./src/main/resources
+
+      - name: Add local application.yml from Secrets
+        run: echo "${{ secrets.APPLICATION_LOCAL }}" > ./src/main/resources/application.yml
+
+      - name: Grant permission to gradlew
+        run: chmod +x ./gradlew
+
+      - name: Build with Gradle (skip tests)
+        run: ./gradlew build -x test
+
+      - name: Build Docker image for local dev
+        run: docker build . -t ${{ env.LOCAL_IMAGE_NAME }}:latest
+
+      - name: Docker login
+        run: echo "${{ secrets.DOCKER_HUB_TOKEN }}" | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
+
+      - name: Push local dev Docker image
+        run: docker push ${{ env.LOCAL_IMAGE_NAME }}:latest


### PR DESCRIPTION
## 📋 작업 내용
- 로컬 실행용 도커 이미지 생성 스크립트 추가

## 🎯 관련 이슈
- 이슈 미생성

## 📝 변경 사항
- [x] APPLICATION_LOCAL secret 추가
- [x] 로컬 실행용 도커 이미지 생성 스크립트 추가

## 📸 스크린샷 (선택사항)
- 필요한 경우 스크린샷 첨부

## ✅ 체크리스트
- [ ] 코드 컨벤션 준수
- [ ] 주석 작성
- [ ] 문서 업데이트
- [ ] 리뷰어 지정

## 💬 리뷰어에게 하고 싶은 말
main 배포 시 로컬용 application.yml 으로 빌드되어
```bash
docker pull munjji/jajaja-local
docker run --name jajaja-local -d -p 8080:8080 -e TZ=Asia/Seoul munjji/jajaja-local
```
명령으로 로컬에서 실행 가능합니다
