### PR TITLE
✨ feat: 기본프로필 관련 개선

### DIFF
--- a/src/main/java/com/jajaja/domain/member/converter/MemberConverter.java
+++ b/src/main/java/com/jajaja/domain/member/converter/MemberConverter.java
@@ -12,6 +12,7 @@ public class MemberConverter {
                 .name(oAuth2Response.getName())
                 .phone(oAuth2Response.getPhone())
                 .email(oAuth2Response.getEmail())
+                .profileKeyName("default-profile-image.png")
                 .point(0)
                 .build();
     }

--- a/src/main/java/com/jajaja/domain/member/dto/response/MemberInfoResponseDto.java
+++ b/src/main/java/com/jajaja/domain/member/dto/response/MemberInfoResponseDto.java
@@ -11,11 +11,11 @@ public record MemberInfoResponseDto(
         String phone,
         String email
 ) {
-    public static MemberInfoResponseDto from(Member member) {
+    public static MemberInfoResponseDto of(Member member, String profileUrl) {
         return MemberInfoResponseDto.builder()
                 .id(member.getId())
                 .name(member.getName())
-                .profileUrl(member.getProfileUrl())
+                .profileUrl(profileUrl)
                 .phone(member.getPhone())
                 .email(member.getEmail())
                 .build();

--- a/src/main/java/com/jajaja/domain/member/entity/Member.java
+++ b/src/main/java/com/jajaja/domain/member/entity/Member.java
@@ -36,15 +36,15 @@ public class Member extends BaseEntity {
     @Column(nullable = false, length = 10)
     private String name;
 
-    @Column(name = "profile_url", length = 512)
-    private String profileUrl;
+    @Column(name = "profile_key_name")
+    private String profileKeyName;
 
     @Column(length = 16)
     private String phone;
 
     @Column(nullable = false)
     private String email;
-    
+
     @Column(nullable = false)
     private Integer point;
 
@@ -52,7 +52,7 @@ public class Member extends BaseEntity {
     private MemberBusinessCategory memberBusinessCategory;
 
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<MemberCoupon> memberCoupons = new ArrayList <>();
+    private List<MemberCoupon> memberCoupons = new ArrayList<>();
 
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<TeamMember> teamMembers = new ArrayList<>();
@@ -86,8 +86,12 @@ public class Member extends BaseEntity {
     public void updateEmail(String email) {
         this.email = email;
     }
-  
-    public void updatePoint(int point) { this.point = point; }
-    
-    public void updateProfileUrl(String profileUrl) { this.profileUrl = profileUrl; }
+
+    public void updatePoint(int point) {
+        this.point = point;
+    }
+
+    public void updateProfileKeyName(String profileKeyName) {
+        this.profileKeyName = profileKeyName;
+    }
 }

--- a/src/main/java/com/jajaja/domain/member/service/MemberCommandServiceImpl.java
+++ b/src/main/java/com/jajaja/domain/member/service/MemberCommandServiceImpl.java
@@ -26,9 +26,13 @@ public class MemberCommandServiceImpl implements MemberCommandService {
         if (request.name() != null) member.updateName(request.name());
         if (request.phone() != null) member.updatePhone(request.phone());
         if (request.profileKeyName() != null) {
-            String imageUrl = s3Service.generateStaticUrl(request.profileKeyName());
-            member.updateProfileUrl(imageUrl);
+            if (request.profileKeyName().isBlank()) {
+                member.updateProfileKeyName("default-profile-image.png");
+            } else {
+                member.updateProfileKeyName(request.profileKeyName());
+            }
         }
-        return MemberInfoResponseDto.from(member);
+        String profileUrl = s3Service.generateStaticUrl(member.getProfileKeyName());
+        return MemberInfoResponseDto.of(member, profileUrl);
     }
 }

--- a/src/main/java/com/jajaja/domain/member/service/MemberQueryServiceImpl.java
+++ b/src/main/java/com/jajaja/domain/member/service/MemberQueryServiceImpl.java
@@ -3,6 +3,7 @@ package com.jajaja.domain.member.service;
 import com.jajaja.domain.member.dto.response.MemberInfoResponseDto;
 import com.jajaja.domain.member.entity.Member;
 import com.jajaja.domain.member.repository.MemberRepository;
+import com.jajaja.global.S3.service.S3Service;
 import com.jajaja.global.apiPayload.code.status.ErrorStatus;
 import com.jajaja.global.apiPayload.exception.custom.BadRequestException;
 import lombok.RequiredArgsConstructor;
@@ -16,11 +17,13 @@ import org.springframework.transaction.annotation.Transactional;
 public class MemberQueryServiceImpl implements MemberQueryService {
 
     private final MemberRepository memberRepository;
+    private final S3Service s3Service;
 
     @Override
     public MemberInfoResponseDto getMemberInfo(Long memberId) {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new BadRequestException(ErrorStatus.MEMBER_NOT_FOUND));
-        return MemberInfoResponseDto.from(member);
+        String profileUrl = s3Service.generateStaticUrl(member.getProfileKeyName());
+        return MemberInfoResponseDto.of(member, profileUrl);
     }
 }


### PR DESCRIPTION
## 📋 작업 내용
- 기본프로필 수정 관련 작업

## 🎯 관련 이슈
- closes #105 

## 📝 변경 사항
- [x] S3에 default-profile-image.png 업로드
- [x] 회원 엔티티에 profileUrl 대신 profileKeyName 저장
- [x] 프로필 업데이트 시 profileKeyName이 공백이라면 "default-profile-image.png"를 키네임으로 저장
- [x] 회원가입 시 기본프로필 지정

## 📸 스크린샷 (선택사항)
<img width="486" height="316" alt="image" src="https://github.com/user-attachments/assets/8a7ae80c-f8ef-488f-950b-b7e7406c1c1c" />

## ✅ 체크리스트
- [x] 코드 컨벤션 준수
- [x] 주석 작성
- [x] 문서 업데이트
- [x] 리뷰어 지정

## 💬 리뷰어에게 하고 싶은 말
- 데이터베이스에는 키네임만 저장하고 반환할때 url로 바꾸는게 맞다고 해서 이렇게 수정해봤습니다!
(버킷 설정 등이 바뀌어도 데이터베이스 수정 없이 url 생성 가능)
- 배포 후 profile_image_url 컬럼 삭제하겠습니다