### PR TITLE
🐛 fix: 데이터 반환 시 저장된 keyName으로부터 URL을 생성하도록 수정

### DIFF
--- a/src/main/java/com/jajaja/domain/team/dto/response/TeamProductItemResponseDto.java
+++ b/src/main/java/com/jajaja/domain/team/dto/response/TeamProductItemResponseDto.java
@@ -1,6 +1,5 @@
 package com.jajaja.domain.team.dto.response;
 
-import com.jajaja.domain.member.entity.Member;
 import com.jajaja.domain.product.entity.Product;
 import com.jajaja.domain.team.entity.Team;
 import lombok.Builder;
@@ -16,14 +15,13 @@ public record TeamProductItemResponseDto(
         Integer discountRate,
         String thumbnailUrl
 ) {
-    public static TeamProductItemResponseDto from(Team team) {
+    public static TeamProductItemResponseDto of(Team team, String profileUrl) {
         Product product = team.getProduct();
-        Member leader = team.getLeader();
 
         return TeamProductItemResponseDto.builder()
                 .teamId(team.getId())
                 .nickname(team.getLeader().getName())
-                .leaderProfileImageUrl(leader.getProfileUrl())
+                .leaderProfileImageUrl(profileUrl)
                 .productId(product.getId())
                 .productName(product.getName())
                 .price(product.getPrice())

--- a/src/main/java/com/jajaja/domain/team/service/TeamQueryServiceImpl.java
+++ b/src/main/java/com/jajaja/domain/team/service/TeamQueryServiceImpl.java
@@ -4,6 +4,7 @@ import com.jajaja.domain.team.dto.response.TeamProductItemResponseDto;
 import com.jajaja.domain.team.dto.response.TeamProductListResponseDto;
 import com.jajaja.domain.team.entity.Team;
 import com.jajaja.domain.team.repository.TeamRepository;
+import com.jajaja.global.S3.service.S3Service;
 import com.jajaja.global.apiPayload.PageResponse;
 import com.jajaja.global.apiPayload.code.status.ErrorStatus;
 import com.jajaja.global.apiPayload.exception.custom.BadRequestException;
@@ -23,6 +24,7 @@ import java.util.List;
 public class TeamQueryServiceImpl implements TeamQueryService {
 
     private final TeamRepository teamRepository;
+    private final S3Service s3Service;
 
     @Override
     public TeamProductListResponseDto getMatchingTeamProducts(int page, int size) {
@@ -34,7 +36,10 @@ public class TeamQueryServiceImpl implements TeamQueryService {
         }
 
         List<TeamProductItemResponseDto> teamDtos = teamPage.getContent().stream()
-                .map(TeamProductItemResponseDto::from)
+                .map(team -> {
+                    String profileUrl = s3Service.generateStaticUrl(team.getLeader().getProfileKeyName());
+                    return TeamProductItemResponseDto.of(team, profileUrl);
+                })
                 .toList();
 
         Page<TeamProductItemResponseDto> mappedPage = new PageImpl<>(teamDtos, pageable, teamPage.getTotalElements());


### PR DESCRIPTION
## 📋 작업 내용
- 데이터 반환 시 저장된 keyName으로부터 URL을 생성하도록 수정

## 🎯 관련 이슈
- closes #105 

## 📝 변경 사항
- [x] getProfileUrl() 대신 프로필 URL을 생성하여 반환

## 📸 스크린샷 (선택사항)
- 필요한 경우 스크린샷 첨부

## ✅ 체크리스트
- [ ] 코드 컨벤션 준수
- [ ] 주석 작성
- [ ] 문서 업데이트
- [ ] 리뷰어 지정

## 💬 리뷰어에게 하고 싶은 말

