### PR TITLE
✨ Feat: 안 읽은 알림 개수 조회 API 구현

### DIFF
--- a/src/main/java/com/jajaja/domain/notification/controller/NotificationController.java
+++ b/src/main/java/com/jajaja/domain/notification/controller/NotificationController.java
@@ -1,17 +1,18 @@
 package com.jajaja.domain.notification.controller;
 
-import java.util.List;
-
+import com.jajaja.domain.notification.dto.NotificationResponseDto;
+import com.jajaja.domain.notification.dto.UnreadCountResponseDto;
 import com.jajaja.domain.notification.repository.NotificationSseEmitterRepository;
+import com.jajaja.domain.notification.service.NotificationService;
+import com.jajaja.global.apiPayload.ApiResponse;
 import com.jajaja.global.security.annotation.Auth;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
-import com.jajaja.global.apiPayload.ApiResponse;
-import com.jajaja.domain.notification.dto.NotificationResponseDto;
-import com.jajaja.domain.notification.service.NotificationService;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/notifications")
@@ -58,4 +59,14 @@ public class NotificationController {
         notificationService.markAllAsRead(memberId);
         return ApiResponse.onSuccess(null);
     }
+
+    @Operation(
+            summary = "읽지 않은 알림 개수 조회 API | by 구름/윤윤지",
+            description = "사용자의 읽지 않은 알림 개수를 반환합니다."
+    )
+    @GetMapping("/unread")
+    public ApiResponse<UnreadCountResponseDto> getUnreadCount(@Auth Long memberId) {
+        return ApiResponse.onSuccess(notificationService.getUnreadCount(memberId));
+    }
+
 }

--- a/src/main/java/com/jajaja/domain/notification/dto/UnreadCountResponseDto.java
+++ b/src/main/java/com/jajaja/domain/notification/dto/UnreadCountResponseDto.java
@@ -1,0 +1,4 @@
+package com.jajaja.domain.notification.dto;
+
+public record UnreadCountResponseDto(int unreadCount) {
+}

--- a/src/main/java/com/jajaja/domain/notification/repository/NotificationRepositoryCustom.java
+++ b/src/main/java/com/jajaja/domain/notification/repository/NotificationRepositoryCustom.java
@@ -1,9 +1,11 @@
 package com.jajaja.domain.notification.repository;
 
 import com.jajaja.domain.notification.entity.Notification;
+
 import java.util.List;
 
 public interface NotificationRepositoryCustom {
     List<Notification> findNotificationsByMemberId(Long memberId);
     int markAllAsReadByMemberId(Long memberId);
+    int countUnreadByMemberId(Long memberId);
 }

--- a/src/main/java/com/jajaja/domain/notification/repository/NotificationRepositoryImpl.java
+++ b/src/main/java/com/jajaja/domain/notification/repository/NotificationRepositoryImpl.java
@@ -5,6 +5,7 @@ import com.jajaja.domain.notification.entity.QNotification;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
+
 import java.util.List;
 
 @Repository
@@ -30,4 +31,14 @@ public class NotificationRepositoryImpl implements NotificationRepositoryCustom 
                 .where(n.member.id.eq(memberId).and(n.isRead.isFalse()))
                 .execute();
     }
+
+    @Override
+    public int countUnreadByMemberId(Long memberId) {
+        QNotification n = QNotification.notification;
+        return (int) queryFactory
+                .selectFrom(n)
+                .where(n.member.id.eq(memberId).and(n.isRead.isFalse()))
+                .fetchCount();
+    }
+
 }

--- a/src/main/java/com/jajaja/domain/notification/repository/NotificationSseEmitterRepository.java
+++ b/src/main/java/com/jajaja/domain/notification/repository/NotificationSseEmitterRepository.java
@@ -1,12 +1,13 @@
 package com.jajaja.domain.notification.repository;
 
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-import org.springframework.stereotype.Component;
-import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 @Component
 public class NotificationSseEmitterRepository {

--- a/src/main/java/com/jajaja/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/jajaja/domain/notification/service/NotificationService.java
@@ -1,12 +1,15 @@
 package com.jajaja.domain.notification.service;
 
-import java.util.List;
 import com.jajaja.domain.notification.dto.NotificationCreateRequestDto;
 import com.jajaja.domain.notification.dto.NotificationResponseDto;
+import com.jajaja.domain.notification.dto.UnreadCountResponseDto;
+
+import java.util.List;
 
 public interface NotificationService {
     Long createNotification(NotificationCreateRequestDto requestDto);
     List<NotificationResponseDto> getNotifications(Long memberId);
     void markAsRead(Long notificationId, Long memberId);
     void markAllAsRead(Long memberId);
+    UnreadCountResponseDto getUnreadCount(Long memberId);
 }

--- a/src/main/java/com/jajaja/domain/notification/service/NotificationServiceImpl.java
+++ b/src/main/java/com/jajaja/domain/notification/service/NotificationServiceImpl.java
@@ -1,8 +1,12 @@
 package com.jajaja.domain.notification.service;
 
-import java.util.List;
-import java.util.stream.Collectors;
-
+import com.jajaja.domain.member.entity.Member;
+import com.jajaja.domain.member.repository.MemberRepository;
+import com.jajaja.domain.notification.dto.NotificationCreateRequestDto;
+import com.jajaja.domain.notification.dto.NotificationResponseDto;
+import com.jajaja.domain.notification.dto.UnreadCountResponseDto;
+import com.jajaja.domain.notification.entity.Notification;
+import com.jajaja.domain.notification.repository.NotificationRepository;
 import com.jajaja.domain.notification.repository.NotificationSseEmitterRepository;
 import com.jajaja.global.apiPayload.code.status.ErrorStatus;
 import com.jajaja.global.apiPayload.exception.custom.BadRequestException;
@@ -10,12 +14,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import com.jajaja.domain.member.entity.Member;
-import com.jajaja.domain.member.repository.MemberRepository;
-import com.jajaja.domain.notification.dto.NotificationCreateRequestDto;
-import com.jajaja.domain.notification.dto.NotificationResponseDto;
-import com.jajaja.domain.notification.entity.Notification;
-import com.jajaja.domain.notification.repository.NotificationRepository;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -72,4 +73,12 @@ public class NotificationServiceImpl implements NotificationService {
             throw new AccessDeniedException(ErrorStatus.NOTIFICATION_ACCESS_DENIED.getMessage());
         }
     }
+
+    @Override
+    @Transactional
+    public UnreadCountResponseDto getUnreadCount(Long memberId) {
+        int count = notificationRepository.countUnreadByMemberId(memberId);
+        return new UnreadCountResponseDto(count);
+    }
+
 }


### PR DESCRIPTION
## 📋 작업 내용
- 안 읽은 알림 개수 조회 API를 추가 구현하였습니다.

## 🎯 관련 이슈
- closes #111 

## 📝 변경 사항
- [ ] 안 읽은 알림 개수 조회 API 구현

## 📸 스크린샷 (선택사항)
- 필요한 경우 스크린샷 첨부

## ✅ 체크리스트
- [ ] 코드 컨벤션 준수
- [ ] 주석 작성
- [ ] 문서 업데이트
- [ ] 리뷰어 지정

## 💬 리뷰어에게 하고 싶은 말
문제 있으면 알려주세요!
