### PR TITLE
✨ FEAT: S3 이미지 정적 URL 로직 공통화 및 응답 추가

### DIFF
--- a/src/main/java/com/jajaja/domain/product/service/ProductQueryServiceImpl.java
+++ b/src/main/java/com/jajaja/domain/product/service/ProductQueryServiceImpl.java
@@ -18,6 +18,7 @@ import com.jajaja.domain.review.dto.response.ReviewItemDto;
 import com.jajaja.domain.review.repository.ReviewImageRepository;
 import com.jajaja.domain.review.repository.ReviewLikeRepository;
 import com.jajaja.domain.review.repository.ReviewRepository;
+import com.jajaja.domain.review.service.ReviewCommonService;
 import com.jajaja.domain.team.dto.response.TeamListDto;
 import com.jajaja.domain.team.entity.Team;
 import com.jajaja.domain.team.repository.TeamRepository;
@@ -25,7 +26,6 @@ import com.jajaja.domain.member.entity.Member;
 import com.jajaja.domain.member.entity.MemberBusinessCategory;
 import com.jajaja.domain.member.repository.MemberBusinessCategoryRepository;
 import com.jajaja.domain.member.repository.MemberRepository;
-import com.jajaja.global.S3.service.S3Service;
 import com.jajaja.global.apiPayload.PageResponse;
 import com.jajaja.global.apiPayload.code.status.ErrorStatus;
 import com.jajaja.global.apiPayload.exception.custom.BadRequestException;
@@ -59,7 +59,7 @@ public class ProductQueryServiceImpl implements ProductQueryService {
     private final ProductSalesRepository productSalesRepository;
     private final ProductCommonService productCommonService;
     private final MemberQueryService memberQueryService;
-    private final S3Service s3Service;
+    private final ReviewCommonService reviewCommonService;
     private final ProductConverter productConverter;
 
     @Override
@@ -110,20 +110,7 @@ public class ProductQueryServiceImpl implements ProductQueryService {
                 ? reviewLikeRepository.findReviewIdsLikedByMember(memberId, reviewIds)
                 : Set.of();
 
-        List<ReviewItemDto> convertedDtos = reviewPageDtos.stream()
-                .map(dto -> new ReviewItemDto(
-                        dto.id(),
-                        dto.memberId(),
-                        dto.nickname(),
-                        s3Service.generateStaticUrl(dto.profileUrl()),
-                        dto.createDate(),
-                        dto.rating(),
-                        dto.option(),
-                        dto.content(),
-                        dto.likeCount(),
-                        dto.imagesCount()
-                ))
-                .toList();
+        List<ReviewItemDto> convertedDtos = reviewCommonService.changeReviewWriterProfile(reviewPageDtos);
 
         List<ReviewListDto> reviewResponseDtoList = convertedDtos.stream()
                 .map(dto -> new ReviewListDto(

--- a/src/main/java/com/jajaja/domain/review/service/ReviewCommonService.java
+++ b/src/main/java/com/jajaja/domain/review/service/ReviewCommonService.java
@@ -1,0 +1,8 @@
+package com.jajaja.domain.review.service;
+
+import com.jajaja.domain.review.dto.response.ReviewItemDto;
+import java.util.List;
+
+public interface ReviewCommonService {
+    List<ReviewItemDto> changeReviewWriterProfile(List<ReviewItemDto> reviewItemDtoList);
+}

--- a/src/main/java/com/jajaja/domain/review/service/ReviewCommonServiceImpl.java
+++ b/src/main/java/com/jajaja/domain/review/service/ReviewCommonServiceImpl.java
@@ -1,0 +1,36 @@
+package com.jajaja.domain.review.service;
+
+import com.jajaja.domain.review.dto.response.ReviewItemDto;
+import com.jajaja.global.S3.service.S3Service;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import jakarta.transaction.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class ReviewCommonServiceImpl implements ReviewCommonService {
+
+    private final S3Service s3Service;
+
+    @Override
+    public List<ReviewItemDto> changeReviewWriterProfile(List<ReviewItemDto> reviewItemDtoList) {
+        return reviewItemDtoList.stream()
+                .map(dto -> new ReviewItemDto(
+                        dto.id(),
+                        dto.memberId(),
+                        dto.nickname(),
+                        s3Service.generateStaticUrl(dto.profileUrl()),
+                        dto.createDate(),
+                        dto.rating(),
+                        dto.option(),
+                        dto.content(),
+                        dto.likeCount(),
+                        dto.imagesCount()
+                ))
+                .toList();
+    }
+
+}

--- a/src/main/java/com/jajaja/domain/review/service/ReviewQueryServiceImpl.java
+++ b/src/main/java/com/jajaja/domain/review/service/ReviewQueryServiceImpl.java
@@ -28,6 +28,7 @@ public class ReviewQueryServiceImpl implements ReviewQueryService {
     private final ReviewRepository reviewRepository;
     private final ReviewLikeRepository reviewLikeRepository;
     private final ReviewImageRepository reviewImageRepository;
+    private final ReviewCommonService reviewCommonService;
 
     @Override
     public ReviewBriefResponseDto getReviewBriefInfo(Long productId) {
@@ -154,7 +155,9 @@ public class ReviewQueryServiceImpl implements ReviewQueryService {
                 ? reviewLikeRepository.findReviewIdsLikedByMember(memberId, reviewIds)
                 : Set.of();
 
-        List<ReviewListDto> reviewDtos = reviewItemPage.stream()
+        List<ReviewItemDto> convertedDtos = reviewCommonService.changeReviewWriterProfile(reviewItemPage.getContent());
+
+        List<ReviewListDto> reviewDtos = convertedDtos.stream()
                 .map(dto -> new ReviewListDto(
                         dto,
                         likedReviewIds.contains(dto.id()),


### PR DESCRIPTION
## 📋 작업 내용
- S3 이미지 정적 URL 변환하는 로직을 공통화하고, 조회 응답에 변환 로직을 추가했습니다.

## 🎯 관련 이슈
- closes #125 

## 📝 변경 사항
- [x] ReviewCommonService 인터페이스 및 Impl에 changeReviewWriterProfile 구현
- [x] 상품 상세 조회, 리뷰 전체 조회 API 응답에 적용

## 📸 스크린샷 (선택사항)
- 필요한 경우 스크린샷 첨부

## ✅ 체크리스트
- [x] 코드 컨벤션 준수
- [x] 주석 작성
- [x] 문서 업데이트
- [x] 리뷰어 지정

## 💬 리뷰어에게 하고 싶은 말

