### PR TITLE
♻️ refactor: 팀 매칭 시, 리더에게만 알림 보내도록 수정

### DIFF
--- a/src/main/java/com/jajaja/domain/team/service/TeamCommonService.java
+++ b/src/main/java/com/jajaja/domain/team/service/TeamCommonService.java
@@ -38,8 +38,6 @@ public class TeamCommonService {
         team.getTeamMembers().add(teamMember);
         team.updateStatus(TeamStatus.COMPLETED);
 
-        // 멤버, 리더 각각에게 팀 매칭 완료 알림 전송 서비스
-        notificationService.createNotification(new NotificationCreateRequestDto(member.getId(), NotificationType.MATCHING, "팀 매칭이 완료되었습니다."));
         notificationService.createNotification(new NotificationCreateRequestDto(leader.getId(), NotificationType.MATCHING, "팀 매칭이 완료되었습니다."));
     }
 }


### PR DESCRIPTION
## 📋 작업 내용
- 팀 매칭 시, 리더에게만 알림 보내도록 수정하였습니다.

## 🎯 관련 이슈
- closes #128 

## 📝 변경 사항
- [x] 팀 참여 서비스에 멤버에게 알림 보내는 메서드를 삭제했습니다.

## 📸 스크린샷 (선택사항)
- 필요한 경우 스크린샷 첨부

## ✅ 체크리스트
- [x] 코드 컨벤션 준수
- [x] 주석 작성
- [x] 문서 업데이트
- [x] 리뷰어 지정

## 💬 리뷰어에게 하고 싶은 말

