### PR TITLE
🐛 fix: 결제 준비 API 요청 파라미터 중 payment method 제거

### DIFF
--- a/src/main/java/com/jajaja/domain/order/controller/OrderController.java
+++ b/src/main/java/com/jajaja/domain/order/controller/OrderController.java
@@ -29,7 +29,7 @@ public class OrderController {
     private final OrderCommandService orderCommandService;
 
     @PostMapping("/prepare")
-    @Operation(summary = "결제 전 준비 API | by 엠마/신윤지", description = "결제 전 주문 데이터를 검증하고 결제에 필요한 merchant_uid를 생성합니다.")
+    @Operation(summary = "결제 전 준비 API | by 엠마/신윤지", description = "결제 전 주문 데이터를 검증하고 결제에 필요한 orderId를 생성합니다.")
     public ApiResponse<OrderPrepareResponseDto> prepareOrder(
             @Auth Long memberId,
             @Valid @RequestBody OrderPrepareRequestDto request) {

--- a/src/main/java/com/jajaja/domain/order/dto/request/OrderPrepareRequestDto.java
+++ b/src/main/java/com/jajaja/domain/order/dto/request/OrderPrepareRequestDto.java
@@ -1,6 +1,5 @@
 package com.jajaja.domain.order.dto.request;
 
-import com.jajaja.domain.order.entity.enums.PaymentMethod;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.PositiveOrZero;
 import lombok.Getter;
@@ -19,10 +18,7 @@ public class OrderPrepareRequestDto {
     private Long addressId;
 
     private String deliveryRequest;
-
-    @NotNull(message = "결제 방법은 필수입니다.")
-    private PaymentMethod paymentMethod;
-
+    
     private Long appliedCouponId;
 
     @PositiveOrZero(message = "포인트는 0 이상이어야 합니다.")

--- a/src/main/java/com/jajaja/domain/order/service/OrderCommandServiceImpl.java
+++ b/src/main/java/com/jajaja/domain/order/service/OrderCommandServiceImpl.java
@@ -96,7 +96,7 @@ public class OrderCommandServiceImpl implements OrderCommandService {
                 .discountAmount(couponDiscount)
                 .pointUsedAmount(request.getPoint() != null ? request.getPoint() : 0)
                 .shippingFee(shippingFee)
-                .paymentMethod(request.getPaymentMethod())
+                .paymentMethod(PaymentMethod.NORMAL)
                 .orderId(orderId)
                 .orderName(orderName)
                 .totalAmount(totalAmount)
@@ -239,7 +239,7 @@ public class OrderCommandServiceImpl implements OrderCommandService {
                 .orElseThrow(() -> new BadRequestException(ErrorStatus.ORDER_NOT_FOUND));
         
         if (!order.getMember().equals(member)) {
-            throw new BadRequestException(ErrorStatus.ORDER_NOT_FOUND);
+            throw new BadRequestException(ErrorStatus.MEMBER_NOT_FOUND);
         }
         
         // 환불이 가능한지 확인


### PR DESCRIPTION
## 📋 작업 내용
- 결제 준비 api의 요청 파라미터 중 payment method 제거

## 🎯 관련 이슈
- closes #이슈번호

## 📝 변경 사항
- [x] 결제 준비 API의 request DTO에서 payment method 제거

## 📸 스크린샷 (선택사항)
- 필요한 경우 스크린샷 첨부

## ✅ 체크리스트
- [x] 코드 컨벤션 준수
- [x] 주석 작성
- [x] 문서 업데이트
- [x] 리뷰어 지정

## 💬 리뷰어에게 하고 싶은 말

