### PR TITLE
✨ feat: Docker 컨테이너에 network를 추가하도록 CI/CD 설정 수정

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -74,7 +74,7 @@ jobs:
             sudo docker pull ${{ env.DOCKER_IMAGE_NAME }}
 
             echo "Running new container $NEW_CONTAINER_NAME"
-            sudo docker run --name $NEW_CONTAINER_NAME -d -p 8080:8080 -e TZ=Asia/Seoul -network jajaja ${{ env.DOCKER_IMAGE_NAME }}
+            sudo docker run --name $NEW_CONTAINER_NAME -d -p 8080:8080 -e TZ=Asia/Seoul --network jajaja ${{ env.DOCKER_IMAGE_NAME }}
 
             echo "Checking health..."
             HEALTH_CHECK_URL="http://127.0.0.1:8080/health"

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -74,7 +74,7 @@ jobs:
             sudo docker pull ${{ env.DOCKER_IMAGE_NAME }}
 
             echo "Running new container $NEW_CONTAINER_NAME"
-            sudo docker run --name $NEW_CONTAINER_NAME -d -p 8080:8080 -e TZ=Asia/Seoul ${{ env.DOCKER_IMAGE_NAME }}
+            sudo docker run --name $NEW_CONTAINER_NAME -d -p 8080:8080 -e TZ=Asia/Seoul -network jajaja ${{ env.DOCKER_IMAGE_NAME }}
 
             echo "Checking health..."
             HEALTH_CHECK_URL="http://127.0.0.1:8080/health"


### PR DESCRIPTION
## 📋 작업 내용
- 갑자기 올라간 컨테이너가 redis를 찾을 수 없다고 하여 같은 네트워크 안에 두었더니 해결되었습니다.
- 새로 배포되는 컨테이너도 같은 네트워크에서 실행되도록 스크립트 수정했습니다

## 🎯 관련 이슈
- closes #147 

## 📝 변경 사항
- [x] jajaja 네트워크 생성
- [x] 네트워크에 컨테이너 추가
- [x] 새로 배포되는 컨테이너가 네트워크에 올라가도록 스크립트 수정

## 📸 스크린샷 (선택사항)
- 필요한 경우 스크린샷 첨부

## ✅ 체크리스트
- [ ] 코드 컨벤션 준수
- [ ] 주석 작성
- [ ] 문서 업데이트
- [ ] 리뷰어 지정

## 💬 리뷰어에게 하고 싶은 말
