### PR TITLE
♻️ refactor: 팀 매칭 성공/실패 시 알림 전송 메서드 수정

### DIFF
--- a/src/main/java/com/jajaja/domain/order/repository/OrderRepository.java
+++ b/src/main/java/com/jajaja/domain/order/repository/OrderRepository.java
@@ -13,5 +13,4 @@ public interface OrderRepository extends JpaRepository<Order, Long>, OrderReposi
     Optional<Order> findById(Long id);
     Optional<Order> findByOrderId(String orderId);
     Boolean existsByMember(Member member);
-    Optional<Order> findByTeamId(Long teamId);
 }

--- a/src/main/java/com/jajaja/domain/order/repository/OrderRepository.java
+++ b/src/main/java/com/jajaja/domain/order/repository/OrderRepository.java
@@ -13,4 +13,5 @@ public interface OrderRepository extends JpaRepository<Order, Long>, OrderReposi
     Optional<Order> findById(Long id);
     Optional<Order> findByOrderId(String orderId);
     Boolean existsByMember(Member member);
+    Optional<Order> findByTeamId(Long teamId);
 }

--- a/src/main/java/com/jajaja/domain/team/repository/TeamRepositoryCustom.java
+++ b/src/main/java/com/jajaja/domain/team/repository/TeamRepositoryCustom.java
@@ -12,6 +12,6 @@ import java.util.Optional;
 public interface TeamRepositoryCustom {
     List<Team> findMatchingTeamsByProductId(Long productId);
     Optional<Team> findByIdWithLeaderMembersAndProduct(Long teamId);
-    List<Team> findExpiredTeamsWithLeader(TeamStatus status, LocalDateTime now);
+    List<Team> findExpiredTeamsWithLeaderAndProduct(TeamStatus status, LocalDateTime now);
     Page<Team> findAllMatchingTeams(Pageable pageable);
 }

--- a/src/main/java/com/jajaja/domain/team/repository/TeamRepositoryCustom.java
+++ b/src/main/java/com/jajaja/domain/team/repository/TeamRepositoryCustom.java
@@ -12,6 +12,6 @@ import java.util.Optional;
 public interface TeamRepositoryCustom {
     List<Team> findMatchingTeamsByProductId(Long productId);
     Optional<Team> findByIdWithLeaderMembersAndProduct(Long teamId);
-    List<Team> findExpiredTeamsWithLeaderAndProduct(TeamStatus status, LocalDateTime now);
+    List<Team> findExpiredTeamsWithAll(TeamStatus status, LocalDateTime now);
     Page<Team> findAllMatchingTeams(Pageable pageable);
 }

--- a/src/main/java/com/jajaja/domain/team/repository/TeamRepositoryCustom.java
+++ b/src/main/java/com/jajaja/domain/team/repository/TeamRepositoryCustom.java
@@ -11,7 +11,7 @@ import java.util.Optional;
 
 public interface TeamRepositoryCustom {
     List<Team> findMatchingTeamsByProductId(Long productId);
-    Optional<Team> findByIdWithLeaderAndMembers(Long teamId);
+    Optional<Team> findByIdWithLeaderMembersAndProduct(Long teamId);
     List<Team> findExpiredTeamsWithLeader(TeamStatus status, LocalDateTime now);
     Page<Team> findAllMatchingTeams(Pageable pageable);
 }

--- a/src/main/java/com/jajaja/domain/team/repository/TeamRepositoryImpl.java
+++ b/src/main/java/com/jajaja/domain/team/repository/TeamRepositoryImpl.java
@@ -41,15 +41,17 @@ public class TeamRepositoryImpl implements TeamRepositoryCustom {
     }
 
     @Override
-    public Optional<Team> findByIdWithLeaderAndMembers(Long teamId) {
+    public Optional<Team> findByIdWithLeaderMembersAndProduct(Long teamId) {
         QTeam team = QTeam.team;
         QMember leader = QMember.member;
         QTeamMember teamMember = QTeamMember.teamMember;
+        QProduct product = QProduct.product;
 
         List<Team> result = queryFactory
                 .selectFrom(team)
                 .join(team.leader, leader).fetchJoin()
                 .leftJoin(team.teamMembers, teamMember).fetchJoin()
+                .join(team.product, product).fetchJoin()
                 .where(team.id.eq(teamId))
                 .fetch();
 

--- a/src/main/java/com/jajaja/domain/team/repository/TeamRepositoryImpl.java
+++ b/src/main/java/com/jajaja/domain/team/repository/TeamRepositoryImpl.java
@@ -59,13 +59,15 @@ public class TeamRepositoryImpl implements TeamRepositoryCustom {
     }
 
     @Override
-    public List<Team> findExpiredTeamsWithLeader(TeamStatus status, LocalDateTime now) {
+    public List<Team> findExpiredTeamsWithLeaderAndProduct(TeamStatus status, LocalDateTime now) {
         QTeam team = QTeam.team;
         QMember leader = QMember.member;
+        QProduct product = QProduct.product;
 
         return queryFactory
                 .selectFrom(team)
                 .join(team.leader, leader).fetchJoin()
+                .join(team.product, product).fetchJoin()
                 .where(team.status.eq(status)
                         .and(team.expireAt.loe(now)))
                 .fetch();

--- a/src/main/java/com/jajaja/domain/team/service/TeamCommandServiceImpl.java
+++ b/src/main/java/com/jajaja/domain/team/service/TeamCommandServiceImpl.java
@@ -53,7 +53,7 @@ public class TeamCommandServiceImpl implements TeamCommandService {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new BadRequestException(ErrorStatus.MEMBER_NOT_FOUND));
 
-        Team team = teamRepository.findByIdWithLeaderAndMembers(teamId)
+        Team team = teamRepository.findByIdWithLeaderMembersAndProduct(teamId)
                 .orElseThrow(() -> new BadRequestException(ErrorStatus.TEAM_NOT_FOUND));
 
         Member leader = team.getLeader();

--- a/src/main/java/com/jajaja/domain/team/service/TeamCommandServiceImpl.java
+++ b/src/main/java/com/jajaja/domain/team/service/TeamCommandServiceImpl.java
@@ -26,7 +26,7 @@ public class TeamCommandServiceImpl implements TeamCommandService {
     private final MemberRepository memberRepository;
     private final ProductRepository productRepository;
     private final TeamRepository teamRepository;
-    private final TeamCommonService teamCommonService;
+    private final TeamCommonServiceImpl teamCommonService;
 
     @Override
     public TeamCreateResponseDto createTeam(Long memberId, Long productId) {

--- a/src/main/java/com/jajaja/domain/team/service/TeamCommonService.java
+++ b/src/main/java/com/jajaja/domain/team/service/TeamCommonService.java
@@ -3,6 +3,7 @@ package com.jajaja.domain.team.service;
 import com.jajaja.domain.notification.dto.request.NotificationCreateRequestDto;
 import com.jajaja.domain.notification.entity.enums.NotificationType;
 import com.jajaja.domain.notification.service.NotificationService;
+import com.jajaja.domain.product.entity.Product;
 import com.jajaja.domain.team.entity.Team;
 import com.jajaja.domain.team.entity.TeamMember;
 import com.jajaja.domain.team.entity.enums.TeamStatus;
@@ -14,12 +15,13 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Map;
+
 @Service
 @RequiredArgsConstructor
 @Transactional
 public class TeamCommonService {
 
-    private final TeamRepository teamRepository;
     private final NotificationService notificationService;
 
     public void joinTeam(Member member, Member leader, Team team) {
@@ -38,6 +40,20 @@ public class TeamCommonService {
         team.getTeamMembers().add(teamMember);
         team.updateStatus(TeamStatus.COMPLETED);
 
-        notificationService.createNotification(NotificationCreateRequestDto.of(leader.getId(), NotificationType.MATCHING, "팀 매칭이 완료되었습니다."));
+        Product product = team.getProduct();
+
+        notificationService.createNotification(
+                NotificationCreateRequestDto.of(
+                        leader.getId(),
+                        NotificationType.MATCHING,
+                        String.format("‘%s’ 팀 매칭이 완료됐습니다.", product.getName()),
+                        Map.of(
+                                "productId", product.getId(),
+                                "productName", product.getName(),
+                                "productImage", product.getThumbnailUrl(),
+                                "isTeamMatched", true
+                        )
+                )
+        );
     }
 }

--- a/src/main/java/com/jajaja/domain/team/service/TeamCommonService.java
+++ b/src/main/java/com/jajaja/domain/team/service/TeamCommonService.java
@@ -46,7 +46,7 @@ public class TeamCommonService {
                 NotificationCreateRequestDto.of(
                         leader.getId(),
                         NotificationType.MATCHING,
-                        "팀 매칭 완료",
+                        String.format("‘%s’ 팀 매칭이 완료됐습니다.", product.getName()),
                         Map.of(
                                 "productId", product.getId(),
                                 "productName", product.getName(),

--- a/src/main/java/com/jajaja/domain/team/service/TeamCommonService.java
+++ b/src/main/java/com/jajaja/domain/team/service/TeamCommonService.java
@@ -3,6 +3,8 @@ package com.jajaja.domain.team.service;
 import com.jajaja.domain.notification.dto.request.NotificationCreateRequestDto;
 import com.jajaja.domain.notification.entity.enums.NotificationType;
 import com.jajaja.domain.notification.service.NotificationService;
+import com.jajaja.domain.order.entity.Order;
+import com.jajaja.domain.order.repository.OrderRepository;
 import com.jajaja.domain.product.entity.Product;
 import com.jajaja.domain.team.entity.Team;
 import com.jajaja.domain.team.entity.TeamMember;
@@ -15,6 +17,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.HashMap;
 import java.util.Map;
 
 @Service
@@ -23,6 +26,7 @@ import java.util.Map;
 public class TeamCommonService {
 
     private final NotificationService notificationService;
+    private final OrderRepository orderRepository;
 
     public void joinTeam(Member member, Member leader, Team team) {
         if (!team.getTeamMembers().isEmpty()) {
@@ -42,17 +46,21 @@ public class TeamCommonService {
 
         Product product = team.getProduct();
 
+        Long teamOrderId = orderRepository.findByTeamId(team.getId())
+                .map(Order::getId)
+                .orElse(null);
+
+        Map<String, Object> data = new HashMap<>();
+        if (teamOrderId != null) data.put("orderId", teamOrderId);
+        data.put("productName", product.getName());
+        data.put("productImage", product.getThumbnailUrl());
+        data.put("isTeamMatched", true);
         notificationService.createNotification(
                 NotificationCreateRequestDto.of(
                         leader.getId(),
                         NotificationType.MATCHING,
                         String.format("‘%s’ 팀 매칭이 완료됐습니다.", product.getName()),
-                        Map.of(
-                                "productId", product.getId(),
-                                "productName", product.getName(),
-                                "productImage", product.getThumbnailUrl(),
-                                "isTeamMatched", true
-                        )
+                        data
                 )
         );
     }

--- a/src/main/java/com/jajaja/domain/team/service/TeamCommonService.java
+++ b/src/main/java/com/jajaja/domain/team/service/TeamCommonService.java
@@ -1,65 +1,8 @@
 package com.jajaja.domain.team.service;
 
-import com.jajaja.domain.notification.dto.request.NotificationCreateRequestDto;
-import com.jajaja.domain.notification.entity.enums.NotificationType;
-import com.jajaja.domain.notification.service.NotificationService;
-import com.jajaja.domain.order.entity.Order;
-import com.jajaja.domain.order.repository.OrderRepository;
-import com.jajaja.domain.product.entity.Product;
-import com.jajaja.domain.team.entity.Team;
-import com.jajaja.domain.team.entity.TeamMember;
-import com.jajaja.domain.team.entity.enums.TeamStatus;
 import com.jajaja.domain.member.entity.Member;
-import com.jajaja.domain.team.repository.TeamRepository;
-import com.jajaja.global.apiPayload.code.status.ErrorStatus;
-import com.jajaja.global.apiPayload.exception.custom.BadRequestException;
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
+import com.jajaja.domain.team.entity.Team;
 
-import java.util.HashMap;
-import java.util.Map;
-
-@Service
-@RequiredArgsConstructor
-@Transactional
-public class TeamCommonService {
-
-    private final NotificationService notificationService;
-
-    public void joinTeam(Member member, Member leader, Team team) {
-        if (!team.getTeamMembers().isEmpty()) {
-            throw new BadRequestException(ErrorStatus.TEAM_ALREADY_HAS_MEMBER);
-        }
-        if (team.getLeader().getId().equals(member.getId())) {
-            throw new BadRequestException(ErrorStatus.CANNOT_JOIN_OWN_TEAM);
-        }
-
-        TeamMember teamMember = TeamMember.builder()
-                .team(team)
-                .member(member)
-                .build();
-
-        team.getTeamMembers().add(teamMember);
-        team.updateStatus(TeamStatus.COMPLETED);
-
-        Product product = team.getProduct();
-        Order order = team.getOrder();
-        Long teamOrderId = (order != null) ? order.getId() : null;
-
-        Map<String, Object> data = new HashMap<>();
-        if (teamOrderId != null) data.put("orderId", teamOrderId);
-        data.put("productName", product.getName());
-        data.put("productImage", product.getThumbnailUrl());
-        data.put("isTeamMatched", true);
-
-        notificationService.createNotification(
-                NotificationCreateRequestDto.of(
-                        leader.getId(),
-                        NotificationType.MATCHING,
-                        String.format("‘%s’ 팀 매칭이 완료됐습니다.", product.getName()),
-                        data
-                )
-        );
-    }
+public interface TeamCommonService {
+    void joinTeam(Member member, Member leader, Team team);
 }

--- a/src/main/java/com/jajaja/domain/team/service/TeamCommonService.java
+++ b/src/main/java/com/jajaja/domain/team/service/TeamCommonService.java
@@ -46,7 +46,7 @@ public class TeamCommonService {
                 NotificationCreateRequestDto.of(
                         leader.getId(),
                         NotificationType.MATCHING,
-                        String.format("‘%s’ 팀 매칭이 완료됐습니다.", product.getName()),
+                        "팀 매칭 완료",
                         Map.of(
                                 "productId", product.getId(),
                                 "productName", product.getName(),

--- a/src/main/java/com/jajaja/domain/team/service/TeamCommonService.java
+++ b/src/main/java/com/jajaja/domain/team/service/TeamCommonService.java
@@ -26,7 +26,6 @@ import java.util.Map;
 public class TeamCommonService {
 
     private final NotificationService notificationService;
-    private final OrderRepository orderRepository;
 
     public void joinTeam(Member member, Member leader, Team team) {
         if (!team.getTeamMembers().isEmpty()) {
@@ -45,16 +44,15 @@ public class TeamCommonService {
         team.updateStatus(TeamStatus.COMPLETED);
 
         Product product = team.getProduct();
-
-        Long teamOrderId = orderRepository.findByTeamId(team.getId())
-                .map(Order::getId)
-                .orElse(null);
+        Order order = team.getOrder();
+        Long teamOrderId = (order != null) ? order.getId() : null;
 
         Map<String, Object> data = new HashMap<>();
         if (teamOrderId != null) data.put("orderId", teamOrderId);
         data.put("productName", product.getName());
         data.put("productImage", product.getThumbnailUrl());
         data.put("isTeamMatched", true);
+
         notificationService.createNotification(
                 NotificationCreateRequestDto.of(
                         leader.getId(),

--- a/src/main/java/com/jajaja/domain/team/service/TeamCommonServiceImpl.java
+++ b/src/main/java/com/jajaja/domain/team/service/TeamCommonServiceImpl.java
@@ -1,0 +1,64 @@
+package com.jajaja.domain.team.service;
+
+import com.jajaja.domain.notification.dto.request.NotificationCreateRequestDto;
+import com.jajaja.domain.notification.entity.enums.NotificationType;
+import com.jajaja.domain.notification.service.NotificationService;
+import com.jajaja.domain.order.entity.Order;
+import com.jajaja.domain.product.entity.Product;
+import com.jajaja.domain.team.entity.Team;
+import com.jajaja.domain.team.entity.TeamMember;
+import com.jajaja.domain.team.entity.enums.TeamStatus;
+import com.jajaja.domain.member.entity.Member;
+import com.jajaja.global.apiPayload.code.status.ErrorStatus;
+import com.jajaja.global.apiPayload.exception.custom.BadRequestException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class TeamCommonServiceImpl implements TeamCommonService {
+
+    private final NotificationService notificationService;
+
+    @Override
+    public void joinTeam(Member member, Member leader, Team team) {
+        if (!team.getTeamMembers().isEmpty()) {
+            throw new BadRequestException(ErrorStatus.TEAM_ALREADY_HAS_MEMBER);
+        }
+        if (team.getLeader().getId().equals(member.getId())) {
+            throw new BadRequestException(ErrorStatus.CANNOT_JOIN_OWN_TEAM);
+        }
+
+        TeamMember teamMember = TeamMember.builder()
+                .team(team)
+                .member(member)
+                .build();
+
+        team.getTeamMembers().add(teamMember);
+        team.updateStatus(TeamStatus.COMPLETED);
+
+        Product product = team.getProduct();
+        Order order = team.getOrder();
+        Long teamOrderId = (order != null) ? order.getId() : null;
+
+        Map<String, Object> data = new HashMap<>();
+        if (teamOrderId != null) data.put("orderId", teamOrderId);
+        data.put("productName", product.getName());
+        data.put("productImage", product.getThumbnailUrl());
+        data.put("isTeamMatched", true);
+
+        notificationService.createNotification(
+                NotificationCreateRequestDto.of(
+                        leader.getId(),
+                        NotificationType.MATCHING,
+                        String.format("‘%s’ 팀 매칭이 완료됐습니다.", product.getName()),
+                        data
+                )
+        );
+    }
+}

--- a/src/main/java/com/jajaja/global/scheduler/TeamExpireScheduler.java
+++ b/src/main/java/com/jajaja/global/scheduler/TeamExpireScheduler.java
@@ -54,7 +54,7 @@ public class TeamExpireScheduler {
                     NotificationCreateRequestDto.of(
                             leader.getId(),
                             NotificationType.MATCHING,
-                            "팀 매칭 실패",
+                            String.format("‘%s’ 팀 매칭이 실패했습니다 .", product.getName()),
                             Map.of(
                                     "productId", product.getId(),
                                     "productName", product.getName(),


### PR DESCRIPTION
## 📋 작업 내용
- 팀 매칭 성공/실패 시 알림 전송 메서드 수정합니다.

## 🎯 관련 이슈
- closes #149 

## 📝 변경 사항
- [x] joinTeam 수정
- [x] TeamExpiredScheduler 수정
- [x] Team QueryDSL 관련 수정

## 📸 스크린샷 (선택사항)
- 필요한 경우 스크린샷 첨부

## ✅ 체크리스트
- [x] 코드 컨벤션 준수
- [x] 주석 작성
- [x] 문서 업데이트
- [x] 리뷰어 지정

## 💬 리뷰어에게 하고 싶은 말
@Yunji-Yun 알림 response DTO 수정에 따라 예시 #144 보면서 작성했는데, 한 번 확인 부탁드립니다 !

**+) 2025.08.14
현재 팀 매칭 성공(팀 참여 api)/실패가 수행됐을 때, Order까지는 진행되지 않아도 테스트 할 수 있게 구현되어 있기 때문에 orderId가 null로 갈거예요!
이 부분은 주문까지 생성된 후에는 orderId가 전송될 거니까, 추후에 팀 생성 -> 주문/결제 -> 팀 매칭 성공/실패 로직으로 확인해보면 orderId 잘 담기는 거 확인할 수 있을 겁니다.
@Yunji-Yun 그리고 위의 상황 때문에 orderId가 null로도 갈 수 있게 가변 형태인 HashMap으로 작성했습니다 ☺️**