### PR TITLE
✨ feat: 주문 목록 조회 시 팀 생성 시간을 함께 반환

### DIFF
--- a/src/main/java/com/jajaja/domain/order/dto/response/OrderItemDto.java
+++ b/src/main/java/com/jajaja/domain/order/dto/response/OrderItemDto.java
@@ -5,19 +5,23 @@ import com.jajaja.domain.order.entity.enums.OrderStatus;
 import com.jajaja.domain.team.entity.enums.TeamStatus;
 import lombok.Builder;
 
+import java.time.LocalDateTime;
+
 @Builder
 public record OrderItemDto(
         long orderProductId,
         OrderStatus status,
         TeamStatus teamStatus,
+        LocalDateTime teamCreatedAt,
         OrderItemProductDto product,
         int price
 ) {
-    public static OrderItemDto of(OrderProduct orderProduct, TeamStatus teamStatus) {
+    public static OrderItemDto of(OrderProduct orderProduct, TeamStatus teamStatus, LocalDateTime teamCreatedAt) {
         return OrderItemDto.builder()
                 .orderProductId(orderProduct.getId())
                 .status(orderProduct.getStatus())
                 .teamStatus(teamStatus)
+                .teamCreatedAt(teamCreatedAt)
                 .product(OrderItemProductDto.from(orderProduct))
                 .price(orderProduct.getPrice())
                 .build();

--- a/src/main/java/com/jajaja/domain/order/service/OrderQueryServiceImpl.java
+++ b/src/main/java/com/jajaja/domain/order/service/OrderQueryServiceImpl.java
@@ -13,6 +13,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -32,8 +33,11 @@ public class OrderQueryServiceImpl implements OrderQueryService {
                     TeamStatus teamStatus = Optional.ofNullable(order.getTeam())
                             .map(Team::getStatus)
                             .orElse(null);
+                    LocalDateTime teamCreatedAt = Optional.ofNullable(order.getTeam())
+                            .map(Team::getCreatedAt)
+                            .orElse(null);
                     List<OrderItemDto> items = order.getOrderProducts().stream()
-                            .map(orderProduct -> OrderItemDto.of(orderProduct, teamStatus))
+                            .map(orderProduct -> OrderItemDto.of(orderProduct, teamStatus, teamCreatedAt))
                             .collect(Collectors.toList());
                     return OrderListDto.of(order, items);
                 })
@@ -48,8 +52,11 @@ public class OrderQueryServiceImpl implements OrderQueryService {
         TeamStatus teamStatus = Optional.ofNullable(order.getTeam())
                 .map(Team::getStatus)
                 .orElse(null);
+        LocalDateTime teamCreatedAt = Optional.ofNullable(order.getTeam())
+                .map(Team::getCreatedAt)
+                .orElse(null);
         List<OrderItemDto> items = order.getOrderProducts().stream()
-                .map(orderProduct -> OrderItemDto.of(orderProduct, teamStatus))
+                .map(orderProduct -> OrderItemDto.of(orderProduct, teamStatus, teamCreatedAt))
                 .collect(Collectors.toList());
         return OrderDetailResponseDto.of(order, items);
     }


### PR DESCRIPTION
## 📋 작업 내용
- 주문 목록 조회 시 팀 생성 시간을 함께 반환

## 🎯 관련 이슈
- closes #153 

## 📝 변경 사항
- [x] OrderItemDto에 teamCreatedAt 추가

## 📸 스크린샷 (선택사항)
<img width="450" height="725" alt="image" src="https://github.com/user-attachments/assets/9aa7a59f-c1fa-4ec7-9ada-c9ee5b1a543f" />

## ✅ 체크리스트
- [x] 코드 컨벤션 준수
- [x] 주석 작성
- [x] 문서 업데이트
- [x] 리뷰어 지정

## 💬 리뷰어에게 하고 싶은 말

