### PR TITLE
🐛 fix: thumbnail, image URL 길이 조건 수정

### DIFF
--- a/src/main/java/com/jajaja/domain/product/entity/Product.java
+++ b/src/main/java/com/jajaja/domain/product/entity/Product.java
@@ -30,10 +30,10 @@ public class Product extends BaseEntity {
     @Column(nullable = false)
     private Integer price;
 
-    @Column(nullable = false)
+    @Column(length = 512, nullable = false)
     private String thumbnailUrl;
 
-    @Column(nullable = false)
+    @Column(length = 512, nullable = false)
     private String imageUrl;
 
     @Column


### PR DESCRIPTION
## 📋 작업 내용
- Product 엔티티의 thumbnail, image URL 필드의 length 옵션을 512로 설정했습니다.

## 🎯 관련 이슈
- closes #161 

## 📝 변경 사항
- [x] thumbnail, image URL 길이 조건 수정

## 📸 스크린샷 (선택사항)
- 필요한 경우 스크린샷 첨부

## ✅ 체크리스트
- [x] 코드 컨벤션 준수
- [x] 주석 작성
- [x] 문서 업데이트
- [x] 리뷰어 지정

## 💬 리뷰어에게 하고 싶은 말
- 먼저 데이터베이스 스키마 직접 수정하여 작업(url 업데이트)하였고 코드는 뒤늦게 수정합니다!
