### PR TITLE
✨ feat: 최초 로그인(회원가입) 후 약관페이지 분기

### DIFF
--- a/src/main/java/com/jajaja/domain/member/controller/MemberController.java
+++ b/src/main/java/com/jajaja/domain/member/controller/MemberController.java
@@ -44,6 +44,11 @@ public class MemberController {
         return ApiResponse.onSuccess(updatedMemberInfo);
     }
 
+    @Operation(
+            summary = "약관 동의",
+            description = "로그인한 사용자가 약관에 동의합니다. \n" +
+                    "약관 동의 후 정상 access, refresh 토큰을 발급받습니다."
+    )
     @PostMapping("/terms/accept")
     public ApiResponse<?> acceptTerms(@Auth Long memberId, HttpServletResponse response) {
         memberCommandService.acceptTerms(memberId, response);

--- a/src/main/java/com/jajaja/domain/member/controller/MemberController.java
+++ b/src/main/java/com/jajaja/domain/member/controller/MemberController.java
@@ -8,6 +8,7 @@ import com.jajaja.global.apiPayload.ApiResponse;
 import com.jajaja.global.security.annotation.Auth;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
@@ -41,5 +42,11 @@ public class MemberController {
                                                                @RequestBody @Valid MemberProfileUpdateRequest request) {
         MemberInfoResponseDto updatedMemberInfo = memberCommandService.updateMemberInfo(memberId, request);
         return ApiResponse.onSuccess(updatedMemberInfo);
+    }
+
+    @PostMapping("/terms/accept")
+    public ApiResponse<?> acceptTerms(@Auth Long memberId, HttpServletResponse response) {
+        memberCommandService.acceptTerms(memberId, response);
+        return ApiResponse.onSuccess(null);
     }
 }

--- a/src/main/java/com/jajaja/domain/member/converter/MemberConverter.java
+++ b/src/main/java/com/jajaja/domain/member/converter/MemberConverter.java
@@ -14,6 +14,7 @@ public class MemberConverter {
                 .email(oAuth2Response.getEmail())
                 .profileKeyName("default-profile-image.png")
                 .point(0)
+                .termsAccepted(false)
                 .build();
     }
 }

--- a/src/main/java/com/jajaja/domain/member/entity/Member.java
+++ b/src/main/java/com/jajaja/domain/member/entity/Member.java
@@ -89,7 +89,7 @@ public class Member extends BaseEntity {
     public void updateEmail(String email) {
         this.email = email;
     }
-  
+
     public void updatePoint(int point) {
         this.point = point;
     }
@@ -101,5 +101,9 @@ public class Member extends BaseEntity {
 
     public void updateProfileKeyName(String profileKeyName) {
         this.profileKeyName = profileKeyName;
+    }
+
+    public void acceptTerms() {
+        this.termsAccepted = true;
     }
 }

--- a/src/main/java/com/jajaja/domain/member/entity/Member.java
+++ b/src/main/java/com/jajaja/domain/member/entity/Member.java
@@ -48,6 +48,9 @@ public class Member extends BaseEntity {
     @Column(nullable = false)
     private Integer point;
 
+    @Column(nullable = false)
+    private boolean termsAccepted;
+
     @OneToOne(mappedBy = "member", fetch = FetchType.LAZY)
     private MemberBusinessCategory memberBusinessCategory;
 

--- a/src/main/java/com/jajaja/domain/member/service/MemberCommandService.java
+++ b/src/main/java/com/jajaja/domain/member/service/MemberCommandService.java
@@ -2,8 +2,11 @@ package com.jajaja.domain.member.service;
 
 import com.jajaja.domain.member.dto.request.MemberProfileUpdateRequest;
 import com.jajaja.domain.member.dto.response.MemberInfoResponseDto;
+import jakarta.servlet.http.HttpServletResponse;
 
 public interface MemberCommandService {
 
     MemberInfoResponseDto updateMemberInfo(Long memberId, MemberProfileUpdateRequest request);
+
+    void acceptTerms(Long memberId, HttpServletResponse response);
 }

--- a/src/main/java/com/jajaja/domain/member/service/MemberCommandServiceImpl.java
+++ b/src/main/java/com/jajaja/domain/member/service/MemberCommandServiceImpl.java
@@ -7,7 +7,11 @@ import com.jajaja.domain.member.repository.MemberRepository;
 import com.jajaja.global.S3.service.S3Service;
 import com.jajaja.global.apiPayload.code.status.ErrorStatus;
 import com.jajaja.global.apiPayload.exception.custom.BadRequestException;
+import com.jajaja.global.security.jwt.JwtProvider;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -18,6 +22,7 @@ public class MemberCommandServiceImpl implements MemberCommandService {
 
     private final MemberRepository memberRepository;
     private final S3Service s3Service;
+    private final JwtProvider jwtProvider;
 
     @Override
     public MemberInfoResponseDto updateMemberInfo(Long memberId, MemberProfileUpdateRequest request) {
@@ -34,5 +39,20 @@ public class MemberCommandServiceImpl implements MemberCommandService {
         }
         String profileUrl = s3Service.generateStaticUrl(member.getProfileKeyName());
         return MemberInfoResponseDto.of(member, profileUrl);
+    }
+
+    @Override
+    public void acceptTerms(Long memberId, HttpServletResponse response) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new BadRequestException(ErrorStatus.MEMBER_NOT_FOUND));
+        if (member.isTermsAccepted()) {
+            throw new BadRequestException(ErrorStatus.TERMS_ALREADY_ACCEPTED);
+        }
+        member.acceptTerms();
+
+        Authentication authentication = new UsernamePasswordAuthenticationToken(String.valueOf(memberId), null, null);
+        String accessToken = jwtProvider.generateAccessToken(authentication);
+        String refreshToken = jwtProvider.generateRefreshToken(authentication);
+        jwtProvider.writeTokenCookies(response, accessToken, refreshToken);
     }
 }

--- a/src/main/java/com/jajaja/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/jajaja/global/apiPayload/code/status/ErrorStatus.java
@@ -29,7 +29,8 @@ public enum ErrorStatus implements BaseErrorCode {
     MEMBER_NOT_FOUND(HttpStatus.BAD_REQUEST, "MEMBER4001", "사용자가 없습니다."),
     MEMBER_BUSINESS_CATEGORY_NOT_FOUND(HttpStatus.BAD_REQUEST, "MEMBERBUSINESS4002", "사용자의 업종 정보가 없습니다."),
     MEMBER_REQUIRED(HttpStatus.BAD_REQUEST, "MEMBER4003", "회원만 사용할 수 있는 기능입니다."),
-    
+    TERMS_ALREADY_ACCEPTED(HttpStatus.BAD_REQUEST, "MEMBER4004", "이미 약관에 동의한 사용자입니다."),
+
     // DELIVERY 관련 에러
     DELIVERY_NOT_FOUND(HttpStatus.BAD_REQUEST, "DELIVERY4001", "배송지가 없습니다."),
     DELIVERY_MEMBER_NOT_MATCH(HttpStatus.BAD_REQUEST, "DELIVERY4002", "배송지의 주인과 현재 로그인한 사용자가 다릅니다."),

--- a/src/main/java/com/jajaja/global/security/SecurityConfig.java
+++ b/src/main/java/com/jajaja/global/security/SecurityConfig.java
@@ -65,6 +65,10 @@ public class SecurityConfig {
                                 .requestMatchers(HttpMethod.GET, GET_WHITELIST).permitAll()
                                 .requestMatchers(HttpMethod.POST, POST_WHITELIST).permitAll()
                                 .requestMatchers(HttpMethod.PATCH, PATCH_WHITELIST).permitAll()
+                                // 약관 동의 API는 CONSENT ROLE 필요
+                                .requestMatchers("/api/members/terms/accept").hasRole("CONSENT")
+                                // 나머지 API는 ACCESS ROLE 필요
+                                .requestMatchers("/api/**").hasRole("ACCESS")
                                 .anyRequest().authenticated()
                 )
                 .addFilter(corsConfig.corsFilter())

--- a/src/main/java/com/jajaja/global/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/jajaja/global/security/jwt/JwtAuthenticationFilter.java
@@ -7,11 +7,14 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
+import java.util.List;
 
 @RequiredArgsConstructor
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
@@ -26,9 +29,18 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
         String token = resolveToken(request);
         if (token != null) {
-            jwtProvider.validateAccessToken(token);
-            Authentication authentication = jwtProvider.getAuthentication(token);
-            SecurityContextHolder.getContext().setAuthentication(authentication);
+            String purpose = jwtProvider.validateAccessToken(token);
+
+            List<GrantedAuthority> authorities = switch (purpose) {
+                case "ACCESS" -> List.of(new SimpleGrantedAuthority("ROLE_ACCESS"));
+                case "CONSENT" -> List.of(new SimpleGrantedAuthority("ROLE_CONSENT"));
+                default -> List.of();
+            };
+
+            if (!authorities.isEmpty()) {
+                Authentication authentication = jwtProvider.getAuthentication(token, authorities);
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+            }
         }
         filterChain.doFilter(request, response);
     }

--- a/src/main/java/com/jajaja/global/security/jwt/JwtProperties.java
+++ b/src/main/java/com/jajaja/global/security/jwt/JwtProperties.java
@@ -13,13 +13,16 @@ public class JwtProperties {
 
     private String secretKey = "";
     private Expiration expiration;
-    private String redirectUrl = "";
+    private String homeRedirectUrl = "";
+    private String agreementRedirectUrl = "";
     private String cookieDomain = "";
+    private String consentPath = "";
 
     @Getter
     @Setter
     public static class Expiration {
         private long access;
         private long refresh;
+        private long consent;
     }
 }

--- a/src/main/java/com/jajaja/global/security/jwt/JwtProvider.java
+++ b/src/main/java/com/jajaja/global/security/jwt/JwtProvider.java
@@ -12,11 +12,13 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseCookie;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 
 import javax.crypto.SecretKey;
 import java.util.Date;
+import java.util.List;
 
 @Component
 @RequiredArgsConstructor
@@ -35,26 +37,32 @@ public class JwtProvider {
     }
 
     public String generateAccessToken(Authentication authentication) {
-        return generateToken(authentication, jwtProperties.getExpiration().getAccess());
+        return generateToken(authentication, jwtProperties.getExpiration().getAccess(), TokenType.ACCESS);
     }
 
     public String generateRefreshToken(Authentication authentication) {
-        return generateToken(authentication, jwtProperties.getExpiration().getRefresh());
+        return generateToken(authentication, jwtProperties.getExpiration().getRefresh(), TokenType.REFRESH);
     }
 
-    public String generateToken(Authentication authentication, long expirationTime) {
+    public String generateConsentToken(Authentication authentication) {
+        return generateToken(authentication, jwtProperties.getExpiration().getConsent(), TokenType.CONSENT);
+    }
+
+    public String generateToken(Authentication authentication, long expirationTime, TokenType tokenType) {
         String memberId = authentication.getName();
         return Jwts.builder()
                 .claim("memberId", Long.parseLong(memberId))
+                .claim("purpose", tokenType.name())
                 .issuedAt(new Date(System.currentTimeMillis()))
                 .expiration(new Date(System.currentTimeMillis() + expirationTime))
                 .signWith(getSigningKey())
                 .compact();
     }
 
-    public void validateAccessToken(String token) {
+    public String validateAccessToken(String token) {
         try {
-            getJwtParser().parseSignedClaims(token);
+            Claims claims = getJwtParser().parseSignedClaims(token).getPayload();
+            return claims.get("purpose", String.class);
         } catch (ExpiredJwtException e) {
             throw new UnauthorizedException(ErrorStatus.EXPIRED_ACCESS_TOKEN);
         } catch (JwtException e) {
@@ -80,6 +88,14 @@ public class JwtProvider {
         return new UsernamePasswordAuthenticationToken(principal, token, null);
     }
 
+    public Authentication getAuthentication(String token, List<GrantedAuthority> authorities) {
+        Claims claims = getJwtParser().parseSignedClaims(token).getPayload();
+        Long memberId = claims.get("memberId", Long.class);
+        MemberDto memberDto = MemberDto.builder().memberId(memberId).build();
+        CustomOAuth2User principal = new CustomOAuth2User(memberDto);
+        return new UsernamePasswordAuthenticationToken(principal, token, authorities);
+    }
+
     public void writeTokenCookies(HttpServletResponse response, String accessToken, String refreshToken) {
         ResponseCookie.ResponseCookieBuilder accessBuilder = ResponseCookie.from("accessToken", accessToken)
                 .path("/")
@@ -103,6 +119,23 @@ public class JwtProvider {
 
         response.addHeader("Set-Cookie", accessBuilder.build().toString());
         response.addHeader("Set-Cookie", refreshBuilder.build().toString());
+    }
+
+    public void writeConsentTokenCookie(HttpServletResponse response, String consentToken) {
+        writeTokenCookies(response, "", "");
+        String consentPath = jwtProperties.getConsentPath();
+        ResponseCookie.ResponseCookieBuilder consentBuilder = ResponseCookie.from("accessToken", consentToken)
+                .path(consentPath)
+                .httpOnly(true)
+                .secure(secure)
+                .sameSite(sameSite)
+                .maxAge(jwtProperties.getExpiration().getConsent() / 1000);
+
+        if (StringUtils.hasText(jwtProperties.getCookieDomain())) {
+            consentBuilder.domain(jwtProperties.getCookieDomain());
+        }
+
+        response.addHeader("Set-Cookie", consentBuilder.build().toString());
     }
 
     private JwtParser getJwtParser() {

--- a/src/main/java/com/jajaja/global/security/jwt/TokenType.java
+++ b/src/main/java/com/jajaja/global/security/jwt/TokenType.java
@@ -1,0 +1,7 @@
+package com.jajaja.global.security.jwt;
+
+public enum TokenType {
+    ACCESS,
+    REFRESH,
+    CONSENT
+}

--- a/src/main/java/com/jajaja/global/security/oauth/CustomOAuth2SuccessHandler.java
+++ b/src/main/java/com/jajaja/global/security/oauth/CustomOAuth2SuccessHandler.java
@@ -1,7 +1,11 @@
 package com.jajaja.global.security.oauth;
 
+import com.jajaja.domain.member.entity.Member;
+import com.jajaja.domain.member.repository.MemberRepository;
 import com.jajaja.domain.redis.entity.RefreshToken;
 import com.jajaja.domain.redis.repository.RefreshTokenRepository;
+import com.jajaja.global.apiPayload.code.status.ErrorStatus;
+import com.jajaja.global.apiPayload.exception.custom.UnauthorizedException;
 import com.jajaja.global.security.jwt.JwtProperties;
 import com.jajaja.global.security.jwt.JwtProvider;
 import jakarta.servlet.ServletException;
@@ -21,14 +25,26 @@ public class CustomOAuth2SuccessHandler implements AuthenticationSuccessHandler 
     private final JwtProvider jwtProvider;
     private final JwtProperties jwtProperties;
     private final RefreshTokenRepository refreshTokenRepository;
+    private final MemberRepository memberRepository;
 
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
+        Long memberId = Long.valueOf(authentication.getName());
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new UnauthorizedException(ErrorStatus.MEMBER_NOT_FOUND));
+
+        if (!member.isTermsAccepted()) {
+            String consentToken = jwtProvider.generateConsentToken(authentication);
+            jwtProvider.writeConsentTokenCookie(response, consentToken);
+            response.sendRedirect(jwtProperties.getAgreementRedirectUrl());
+            return;
+        }
+
         String accessToken = jwtProvider.generateAccessToken(authentication);
         String refreshToken = jwtProvider.generateRefreshToken(authentication);
         RefreshToken refreshTokenEntity = new RefreshToken(authentication.getName(), refreshToken);
         refreshTokenRepository.save(refreshTokenEntity);
         jwtProvider.writeTokenCookies(response, accessToken, refreshToken);
-        response.sendRedirect(jwtProperties.getRedirectUrl());
+        response.sendRedirect(jwtProperties.getHomeRedirectUrl());
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -61,7 +61,10 @@ jwt:
     expiration:
       access: ${JWT_EXPIRATION_ACCESS}
       refresh: ${JWT_EXPIRATION_REFRESH}
-    redirect-url: ${AUTH_REDIRECT_URL}
+      consent: ${JWT_EXPIRATION_CONSENT}
+    home-redirect-url: ${HOME_REDIRECT_URL}
+    agreement-redirect-url: ${AGREEMENT_REDIRECT_URL}
+    consent-path: ${CONSENT_PATH}
     cookie-domain: ${COOKIE_DOMAIN}
     same-site: ${COOKIE_SAME_SITE}
     secure: ${COOKIE_SECURE}


### PR DESCRIPTION
## 📋 작업 내용
- Member 엔티티에 termsAccepted 필드 추가 (기본값 false)
- termsAccepted가 false라면 /agreement로 리다이렉트 되며, 10분 뒤 만료되는 consentToken 전달 (/agreement에서만 유효)
- consentToken으로는 /api/members/terms/accept 외 api 접근 불가
- 약관 동의 엔드포인트 호출 시 정상 access/refresh 토큰 발급

## 🎯 관련 이슈
- closes #163 

## 📝 변경 사항
- [x] application.yml에 jwt 관련 설정 추가

## 📸 스크린샷 (선택사항)
- 필요한 경우 스크린샷 첨부

## ✅ 체크리스트
- [x] 코드 컨벤션 준수
- [x] 주석 작성
- [x] 문서 업데이트
- [x] 리뷰어 지정

## 💬 리뷰어에게 하고 싶은 말
- 수정된 파일이 많아서 커밋 단위로 보시면 파악이 쉬울 것 같습니다!!
