### PR TITLE
🐛 fix: 내 주문 목록에서 imageUrl 대신 thumbnailUrl 반환

### DIFF
--- a/src/main/java/com/jajaja/domain/order/dto/response/OrderItemProductDto.java
+++ b/src/main/java/com/jajaja/domain/order/dto/response/OrderItemProductDto.java
@@ -15,7 +15,7 @@ public record OrderItemProductDto(
     public static OrderItemProductDto from(OrderProduct orderProduct) {
         return OrderItemProductDto.builder()
                 .id(orderProduct.getProduct().getId())
-                .image(orderProduct.getProduct().getImageUrl())
+                .image(orderProduct.getProduct().getThumbnailUrl())
                 .store(orderProduct.getProduct().getStore())
                 .name(orderProduct.getProduct().getName())
                 .option(orderProduct.getProductOption() == null ? null : orderProduct.getProductOption().getName())


### PR DESCRIPTION
## 📋 작업 내용
- 내 주문 목록에서 imageUrl 대신 thumbnailUrl 반환

## 🎯 관련 이슈
- closes #168 

## 📝 변경 사항
- [x] 내 주문 목록에서 imageUrl 대신 thumbnailUrl 반환

## 📸 스크린샷 (선택사항)
- 필요한 경우 스크린샷 첨부

## ✅ 체크리스트
- [x] 코드 컨벤션 준수
- [x] 주석 작성
- [x] 문서 업데이트
- [x] 리뷰어 지정

## 💬 리뷰어에게 하고 싶은 말

