### PR TITLE
:sparkles: feat: 비회원 팀 모집 상품 목록 조회 API 권한 수정

### DIFF
--- a/src/main/java/com/jajaja/global/security/SecurityConfig.java
+++ b/src/main/java/com/jajaja/global/security/SecurityConfig.java
@@ -34,7 +34,7 @@ public class SecurityConfig {
     };
 
     private static final String[] GET_WHITELIST = {
-            "/api/products/**", "/api/search/**", "/api/categories/**", "/api/reviews/**", "/api/search/recent-keywords"
+            "/api/products/**", "/api/search/**", "/api/categories/**", "/api/reviews/**", "/api/search/recent-keywords", "/api/teams/products"
     };
 
     private static final String[] POST_WHITELIST = {


### PR DESCRIPTION
## 📋 작업 내용
- 비회원인 상태로 게시판 내 팀 모집 상품 목록을 조회할 수 있도록 권한을 수정했습니다.

## 🎯 관련 이슈
- closes #170 

## 📝 변경 사항
- [x] SecurityConfig 내 GET_WHITELIST에 /api/teams/products 추가

## 📸 스크린샷 (선택사항)
- 필요한 경우 스크린샷 첨부

## ✅ 체크리스트
- [x] 코드 컨벤션 준수
- [x] 주석 작성
- [x] 문서 업데이트
- [x] 리뷰어 지정

## 💬 리뷰어에게 하고 싶은 말

