### PR TITLE
✨ feat: 장바구니 조회 시 team Price도 리턴하게 추가

### DIFF
--- a/src/main/java/com/jajaja/domain/cart/dto/CartProductResponseDto.java
+++ b/src/main/java/com/jajaja/domain/cart/dto/CartProductResponseDto.java
@@ -15,11 +15,12 @@ public record CartProductResponseDto(
 		String optionName,
 		int quantity,
 		String productThumbnail,
-		int unitPrice,
+		int individualPrice,
+		int teamPrice,
 		int totalPrice,
 		boolean teamAvailable
 ) {
-	public static CartProductResponseDto of(CartProduct cartProduct, boolean isTeamAvailable) {
+	public static CartProductResponseDto of(CartProduct cartProduct, int teamPrice, boolean isTeamAvailable) {
 		Product product = cartProduct.getProduct();
 		ProductOption option = cartProduct.getProductOption();
 		
@@ -36,7 +37,8 @@ public record CartProductResponseDto(
 				.optionName(optionName)
 				.quantity(cartProduct.getQuantity())
 				.productThumbnail(product.getThumbnailUrl())
-				.unitPrice(price)
+				.individualPrice(price)
+				.teamPrice(teamPrice)
 				.totalPrice(cartProduct.getUnitPrice() * cartProduct.getQuantity())
 				.teamAvailable(isTeamAvailable)
 				.build();

--- a/src/main/java/com/jajaja/domain/cart/service/CartQueryServiceImpl.java
+++ b/src/main/java/com/jajaja/domain/cart/service/CartQueryServiceImpl.java
@@ -4,6 +4,7 @@ import com.jajaja.domain.cart.converter.CartConverter;
 import com.jajaja.domain.cart.dto.CartProductResponseDto;
 import com.jajaja.domain.cart.dto.CartResponseDto;
 import com.jajaja.domain.cart.entity.Cart;
+import com.jajaja.domain.product.service.ProductCommonService;
 import com.jajaja.global.common.dto.PriceInfoDto;
 import com.jajaja.domain.coupon.service.CouponCommonService;
 import com.jajaja.domain.team.entity.enums.TeamStatus;
@@ -25,6 +26,7 @@ public class CartQueryServiceImpl implements CartQueryService {
 	private final CartCommonService cartCommonService;
 	private final TeamCommandRepository teamRepository;
 	private final CouponCommonService couponCommonService;
+	private final ProductCommonService productCommonService;
 	
 	@Override
 	public CartResponseDto getCart(Long memberId) {
@@ -43,7 +45,7 @@ public class CartQueryServiceImpl implements CartQueryService {
 		List<CartProductResponseDto> itemInfos = cart.getCartProducts().stream()
 				.map(	cartProduct -> {
 					boolean isTeamAvailable = teamRepository.existsByProductIdAndStatus(cartProduct.getProduct().getId(), TeamStatus.MATCHING);
-					return CartProductResponseDto.of(cartProduct, isTeamAvailable);
+					return CartProductResponseDto.of(cartProduct, productCommonService.calculateDiscountedPrice(cartProduct.getUnitPrice(), cartProduct.getProduct().getDiscountRate()), isTeamAvailable);
 				})
 				.collect(Collectors.toList());
 		

--- a/src/main/java/com/jajaja/domain/order/service/OrderCommandServiceImpl.java
+++ b/src/main/java/com/jajaja/domain/order/service/OrderCommandServiceImpl.java
@@ -100,7 +100,7 @@ public class OrderCommandServiceImpl implements OrderCommandService {
         int couponDiscount = calculateCouponDiscount(coupon, totalAmount);
         int shippingFee = calculateShippingFee(delivery);
         int pointDiscount = request.point() != null ? request.point() : 0;
-		int finalAmount = totalAmount - couponDiscount - (pointDiscount) + shippingFee;
+		int finalAmount = totalAmount - couponDiscount - pointDiscount + shippingFee;
         String orderId = memberId + "ORDER-" + UUID.randomUUID();
         String orderName = cartProducts.get(0).getProduct().getName() + (cartProducts.size() > 1 ? " 외 " + (cartProducts.size() - 1) + "건" : "");
         


### PR DESCRIPTION
## 📋 작업 내용
- 프론트엔드 요청으로 장바구니 조회 시 teamPrice도 같이 리턴할 수 있게 하였습니다.

## 🎯 관련 이슈

## 📝 변경 사항
- [x] 장바구니 조회 시 teamPrice도 함께 리턴
- [x] API 명세서 수정

## 📸 스크린샷 (선택사항)
<img width="1074" height="383" alt="Screenshot 2025-08-15 at 23 15 30" src="https://github.com/user-attachments/assets/41ad6310-edba-4726-94dc-8e0994362917" />


## ✅ 체크리스트
- [x] 코드 컨벤션 준수
- [x] 주석 작성
- [x] 문서 업데이트
- [x] 리뷰어 지정

## 💬 리뷰어에게 하고 싶은 말

