### PR TITLE
✨ feat: 장바구니 상품 추가/수정 시 반환값 수정, 결제시간이 만료된 주문의 상태가 자동으로 변경되는 scheduler 추가

### DIFF
--- a/src/main/java/com/jajaja/domain/cart/controller/CartController.java
+++ b/src/main/java/com/jajaja/domain/cart/controller/CartController.java
@@ -35,9 +35,8 @@ public class CartController {
 			summary = "장바구니 아이템 추가 및 수정 API | by 엠마/신윤지",
 			description = "장바구니에 아이템을 추가하거나 수량을 수정합니다.")
 	@PostMapping("/products")
-	public ApiResponse<String> addOrUpdateCartProduct(@Auth Long memberId, @RequestBody @Valid List<CartProductAddRequestDto> request) {
-		cartCommandService.addOrUpdateCartProduct(memberId, request);
-		return ApiResponse.onSuccess("성공적으로 장바구니에 상품이 추가/수정되었습니다.");
+	public ApiResponse<CartResponseDto> addOrUpdateCartProduct(@Auth Long memberId, @RequestBody @Valid List<CartProductAddRequestDto> request) {
+		return ApiResponse.onSuccess(cartCommandService.addOrUpdateCartProduct(memberId, request));
 	}
 	
 	@Operation(

--- a/src/main/java/com/jajaja/domain/cart/service/CartCommandService.java
+++ b/src/main/java/com/jajaja/domain/cart/service/CartCommandService.java
@@ -1,11 +1,12 @@
 package com.jajaja.domain.cart.service;
 
 import com.jajaja.domain.cart.dto.CartProductAddRequestDto;
+import com.jajaja.domain.cart.dto.CartResponseDto;
 
 import java.util.List;
 
 public interface CartCommandService {
-	void addOrUpdateCartProduct(Long memberId, List<CartProductAddRequestDto> request);
+	CartResponseDto addOrUpdateCartProduct(Long memberId, List<CartProductAddRequestDto> request);
 	void deleteCartProduct(Long memberId, Long productId, Long optionId);
 	void deleteCartProducts(Long memberId, List<Long> cartProductIds);
 }

--- a/src/main/java/com/jajaja/domain/cart/service/CartCommandServiceImpl.java
+++ b/src/main/java/com/jajaja/domain/cart/service/CartCommandServiceImpl.java
@@ -1,6 +1,9 @@
 package com.jajaja.domain.cart.service;
 
+import com.jajaja.domain.cart.converter.CartConverter;
 import com.jajaja.domain.cart.dto.CartProductAddRequestDto;
+import com.jajaja.domain.cart.dto.CartProductResponseDto;
+import com.jajaja.domain.cart.dto.CartResponseDto;
 import com.jajaja.domain.cart.entity.Cart;
 import com.jajaja.domain.cart.entity.CartProduct;
 import com.jajaja.domain.cart.repository.CartProductRepository;
@@ -11,8 +14,12 @@ import com.jajaja.domain.product.entity.Product;
 import com.jajaja.domain.product.entity.ProductOption;
 import com.jajaja.domain.product.repository.ProductOptionRepository;
 import com.jajaja.domain.product.repository.ProductRepository;
+import com.jajaja.domain.product.service.ProductCommonService;
+import com.jajaja.domain.team.entity.enums.TeamStatus;
+import com.jajaja.domain.team.repository.TeamCommandRepository;
 import com.jajaja.global.apiPayload.code.status.ErrorStatus;
 import com.jajaja.global.apiPayload.exception.handler.CartHandler;
+import com.jajaja.global.common.dto.PriceInfoDto;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -27,15 +34,17 @@ import java.util.Optional;
 @Transactional
 public class CartCommandServiceImpl implements CartCommandService {
 	
-	private final CartCommonService cartCommonService;
-	private final CouponCommonService couponCommonService;
 	private final CartProductRepository cartProductRepository;
 	private final ProductRepository productRepository;
+	private final TeamCommandRepository teamRepository;
 	private final ProductOptionRepository productOptionRepository;
 	private final MemberCouponRepository memberCouponRepository;
+	private final CouponCommonService couponCommonService;
+	private final ProductCommonService productCommonService;
+	private final CartCommonService cartCommonService;
 	
 	@Override
-	public void addOrUpdateCartProduct(Long memberId, List<CartProductAddRequestDto> request) {
+	public CartResponseDto addOrUpdateCartProduct(Long memberId, List<CartProductAddRequestDto> request) {
 		Cart cart = cartCommonService.findCart(memberId);
 		request.forEach(req -> {
 			log.info("[CartCommandService] 사용자 {}의 장바구니에 아이템 {} 추가/수정", memberId, req.productId());
@@ -58,7 +67,21 @@ public class CartCommandServiceImpl implements CartCommandService {
 					}
 			);
 		});
+		
+		List<CartProductResponseDto> items = cart.getCartProducts().stream()
+						.map(cartProduct -> {
+							boolean isTeamAvailable = teamRepository.existsByProductIdAndStatus(cartProduct.getProduct().getId(), TeamStatus.MATCHING);
+							return CartProductResponseDto.of(cartProduct, productCommonService.calculateDiscountedPrice(cartProduct.getUnitPrice(), cartProduct.getProduct().getDiscountRate()), isTeamAvailable);
+						})
+				.toList();
+		
+		
+		PriceInfoDto priceInfo = cart.getCoupon() != null ?
+				couponCommonService.calculateDiscount(cart, cart.getCoupon()) :
+				PriceInfoDto.noDiscount(cart.calculateTotalAmount());
+		
 		revalidateAppliedCouponIfExists(cart);
+		return CartConverter.toCartResponseDto(cart, items, priceInfo);
 	}
 	
 	@Override

--- a/src/main/java/com/jajaja/domain/order/repository/OrderRepository.java
+++ b/src/main/java/com/jajaja/domain/order/repository/OrderRepository.java
@@ -2,15 +2,18 @@ package com.jajaja.domain.order.repository;
 
 import com.jajaja.domain.member.entity.Member;
 import com.jajaja.domain.order.entity.Order;
+import com.jajaja.domain.order.entity.enums.OrderStatus;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 public interface OrderRepository extends JpaRepository<Order, Long>, OrderRepositoryCustom {
-
     @EntityGraph(attributePaths = {"orderProducts", "orderProducts.product", "orderProducts.productOption", "team", "delivery"})
     Optional<Order> findById(Long id);
     Optional<Order> findByOrderId(String orderId);
     Boolean existsByMember(Member member);
+    List<Order> findOrdersByOrderStatusAndCreatedAtBefore(OrderStatus orderStatus, LocalDateTime createdAtBefore);
 }

--- a/src/main/java/com/jajaja/domain/order/service/OrderCommandService.java
+++ b/src/main/java/com/jajaja/domain/order/service/OrderCommandService.java
@@ -11,5 +11,5 @@ public interface OrderCommandService {
     OrderPrepareResponseDto prepareOrder(Long memberId, OrderPrepareRequestDto request);
     OrderApproveResponseDto approveOrder(Long memberId, OrderApproveRequestDto request);
     OrderRefundResponseDto refundOrder(Long memberId, OrderRefundRequestDto request);
-    void startShipping(Long orderId);
-}
+    void expireOrder();
+    void startShipping(Long orderId);}

--- a/src/main/java/com/jajaja/global/scheduler/OrderExpireScheduler.java
+++ b/src/main/java/com/jajaja/global/scheduler/OrderExpireScheduler.java
@@ -1,0 +1,22 @@
+package com.jajaja.global.scheduler;
+
+import com.jajaja.domain.order.service.OrderCommandService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class OrderExpireScheduler {
+
+	private final OrderCommandService orderCommandService;
+	
+	@Scheduled(fixedDelay = 60000)
+	public void expireOrders() {
+		log.info("[OrderExpireScheduler] 만료된 주문 처리 스케줄러 시작");
+		orderCommandService.expireOrder();
+		log.info("[OrderExpireScheduler] 만료된 주문 처리 스케줄러 완료");
+	}
+}


### PR DESCRIPTION
## 📋 작업 내용
- 장바구니 추가/수정 API 실행 시 추가된 데이터를 포함해 카트 데이터 전원 반환하도록 수정
- 결제시간이 만료된 주문의 상태가 자동으로 변경되는 scheduler 추가

## 🎯 관련 이슈
- closes #184 

## 📝 변경 사항
- [x]  장바구니 상품 추가/수정 시 새로 추가된 데이터를 반환하도록 수정
- [x] 생성시간으로부터 결제시간(10분)이 지났는데 아직도 상태가 Ready(결제 승인 X)인 주문의 상태가 자동으로 변경되는 scheduler 추가

## 📸 스크린샷 (선택사항)
1. 장바구니 상품 추가/수정 데이터 관련
<img width="421" height="652" alt="Screenshot 2025-08-19 at 16 41 03" src="https://github.com/user-attachments/assets/8e1bc698-037f-44ea-b49a-05ed4e598901" />


2. 생성 시간 만료 데이터 처리
<img width="491" height="244" alt="Screenshot 2025-08-19 at 13 34 31" src="https://github.com/user-attachments/assets/7e5d49a6-c5e0-45b8-864a-16aa2a1f190a" />

<img width="582" height="229" alt="Screenshot 2025-08-19 at 13 34 36" src="https://github.com/user-attachments/assets/218073f4-28aa-4c42-97a7-7f56c69fa82f" />


## ✅ 체크리스트
- [x] 코드 컨벤션 준수
- [x] 주석 작성
- [x] 문서 업데이트
- [x] 리뷰어 지정

## 💬 리뷰어에게 하고 싶은 말

