### PR TITLE
🐛 fix: 리뷰 생성 시 orderProductId를 받도록 수정

### DIFF
--- a/src/main/java/com/jajaja/domain/order/repository/OrderProductRepository.java
+++ b/src/main/java/com/jajaja/domain/order/repository/OrderProductRepository.java
@@ -1,10 +1,13 @@
 package com.jajaja.domain.order.repository;
 
 import com.jajaja.domain.order.entity.OrderProduct;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
 public interface OrderProductRepository extends JpaRepository<OrderProduct, Long> {
-    Optional<OrderProduct> findByOrderMemberIdAndProductId(Long memberId, Long productId);
+
+    @EntityGraph(attributePaths = {"product"})
+    Optional<OrderProduct> findById(Long orderProductId);
 }

--- a/src/main/java/com/jajaja/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/jajaja/domain/review/controller/ReviewController.java
@@ -100,13 +100,13 @@ public class ReviewController {
                             해당 key 값을 imageKeys로 전달해주세요.
                           """
     )
-    @PostMapping("/{productId}")
+    @PostMapping("/{orderProductId}")
     public ApiResponse<ReviewCreateResponseDto> createReview(
             @Auth Long memberId,
-            @PathVariable Long productId,
+            @PathVariable Long orderProductId,
             @Valid @RequestBody ReviewCreateRequestDto requestDto
     ) {
-        Long reviewId = reviewCommandService.createReview(memberId, productId, requestDto);
+        Long reviewId = reviewCommandService.createReview(memberId, orderProductId, requestDto);
         return ApiResponse.onSuccess(new ReviewCreateResponseDto(reviewId));
     }
 

--- a/src/main/java/com/jajaja/domain/review/service/ReviewCommandServiceImpl.java
+++ b/src/main/java/com/jajaja/domain/review/service/ReviewCommandServiceImpl.java
@@ -5,8 +5,6 @@ import com.jajaja.domain.member.repository.MemberRepository;
 import com.jajaja.domain.order.entity.OrderProduct;
 import com.jajaja.domain.order.repository.OrderProductRepository;
 import com.jajaja.domain.point.service.PointCommandService;
-import com.jajaja.domain.product.entity.Product;
-import com.jajaja.domain.product.repository.ProductRepository;
 import com.jajaja.domain.review.dto.request.ReviewCreateRequestDto;
 import com.jajaja.domain.review.entity.Review;
 import com.jajaja.domain.review.entity.ReviewImage;
@@ -28,7 +26,6 @@ import java.util.List;
 public class ReviewCommandServiceImpl implements ReviewCommandService {
 
     private final MemberRepository memberRepository;
-    private final ProductRepository productRepository;
     private final OrderProductRepository orderProductRepository;
     private final ReviewRepository reviewRepository;
     private final ReviewImageRepository reviewImageRepository;
@@ -36,13 +33,11 @@ public class ReviewCommandServiceImpl implements ReviewCommandService {
     private final PointCommandService pointCommandService;
 
     @Override
-    public Long createReview(Long memberId, Long productId, ReviewCreateRequestDto dto) {
+    public Long createReview(Long memberId, Long orderProductId, ReviewCreateRequestDto dto) {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new UnauthorizedException(ErrorStatus.MEMBER_NOT_FOUND));
-        Product product = productRepository.findById(productId)
-                .orElseThrow(() -> new BadRequestException(ErrorStatus.PRODUCT_NOT_FOUND));
 
-        OrderProduct orderProduct = orderProductRepository.findByOrderMemberIdAndProductId(memberId, productId)
+        OrderProduct orderProduct = orderProductRepository.findById(orderProductId)
                 .orElseThrow(() -> new BadRequestException(ErrorStatus.REVIEW_NOT_ALLOWED));
 
         if (reviewRepository.existsByOrderProduct(orderProduct)) {
@@ -51,7 +46,7 @@ public class ReviewCommandServiceImpl implements ReviewCommandService {
 
         Review review = Review.builder()
                 .member(member)
-                .product(product)
+                .product(orderProduct.getProduct())
                 .orderProduct(orderProduct)
                 .rating(dto.rating().byteValue())
                 .content(dto.content())


### PR DESCRIPTION
## 📋 작업 내용
- 리뷰 생성 시 orderProductId를 받도록 수정

## 🎯 관련 이슈
- closes #196 

## 📝 변경 사항
- [x] 리뷰 생성 시 orderProductId를 받도록 수정

## 📸 스크린샷 (선택사항)
- 필요한 경우 스크린샷 첨부

## ✅ 체크리스트
- [x] 코드 컨벤션 준수
- [x] 주석 작성
- [x] 문서 업데이트
- [x] 리뷰어 지정

## 💬 리뷰어에게 하고 싶은 말
- 원래 리뷰 작성 시 productId, memberId로 orderProduct를 가져왔는데, 같은 상품을 두번 주문한경우 어떤 orderProduct를 가져올지 몰라서 에러 발생 -> 처음부터 orderProductId를 받도록 수정
